### PR TITLE
Harden backend gate for no-DB local checks

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -182,6 +182,18 @@ One-command backend gate (without HTTP preflight):
 .venv/bin/python scripts/run_backend_gate.py
 ```
 
+If local PostgreSQL is unavailable, run only non-DB checks:
+
+```bash
+.venv/bin/python scripts/run_backend_gate.py --skip-db
+```
+
+Shell wrapper (auto-picks `backend/.venv`, then repo-root `.venv`):
+
+```bash
+./run_gate.sh --skip-db
+```
+
 Apply retention cleanup (non-dry-run):
 
 ```bash

--- a/backend/run_gate.sh
+++ b/backend/run_gate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -x "${SCRIPT_DIR}/.venv/bin/python" ]]; then
+  PYTHON_BIN="${SCRIPT_DIR}/.venv/bin/python"
+elif [[ -x "${REPO_ROOT}/.venv/bin/python" ]]; then
+  PYTHON_BIN="${REPO_ROOT}/.venv/bin/python"
+else
+  PYTHON_BIN="python3"
+fi
+
+echo "[INFO] Using python: ${PYTHON_BIN}"
+exec "${PYTHON_BIN}" "${SCRIPT_DIR}/scripts/run_backend_gate.py" "$@"
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the same checks as CI (`scripts/run_backend_gate.py`) using a project venv.
+# Avoids PEP 668 failures from `python3 -m pip` / system interpreters on macOS/Homebrew.
+
+BACKEND_ROOT="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$BACKEND_ROOT/.." && pwd)"
+
+PY=""
+if [[ -x "$BACKEND_ROOT/.venv/bin/python" ]]; then
+  PY="$BACKEND_ROOT/.venv/bin/python"
+elif [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
+  PY="$REPO_ROOT/.venv/bin/python"
+fi
+
+if [[ -z "$PY" ]]; then
+  cat <<EOF >&2
+HiAir: no Python virtualenv found for the backend gate.
+
+Create a venv and install dependencies (pick one layout):
+
+  cd "$BACKEND_ROOT" && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
+
+Or a shared venv at the repository root:
+
+  cd "$REPO_ROOT" && python3 -m venv .venv && .venv/bin/pip install -r backend/requirements.txt
+
+On macOS with Homebrew Python, global pip fails with PEP 668 — always use a venv.
+EOF
+  exit 1
+fi
+
+# Examples: ./run_gate.sh | ./run_gate.sh --skip-db | ./run_gate.sh --skip-db --base-url http://127.0.0.1:8000
+exec "$PY" "$BACKEND_ROOT/scripts/run_backend_gate.py" "$@"

--- a/backend/scripts/run_backend_gate.py
+++ b/backend/scripts/run_backend_gate.py
@@ -1,7 +1,22 @@
 import argparse
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+
+def _load_dotenv(env_file: Path) -> None:
+    if not env_file.exists():
+        return
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip("'").strip('"')
+        if key and key not in os.environ:
+            os.environ[key] = value
 
 
 def main() -> int:
@@ -16,19 +31,49 @@ def main() -> int:
         action="store_true",
         help="Skip smoke flow execution.",
     )
+    parser.add_argument(
+        "--skip-db",
+        action="store_true",
+        help="Skip database-dependent steps (init_db, retention_cleanup, smoke_db_flow).",
+    )
+    parser.add_argument(
+        "--env-file",
+        default=None,
+        help="Optional dotenv file to preload into environment (defaults to backend/.env.local when present).",
+    )
     args = parser.parse_args()
 
     root = Path(__file__).resolve().parents[1]
+    default_env = root / ".env.local"
+    env_path = Path(args.env_file).expanduser() if args.env_file else default_env
+    if env_path.exists():
+        _load_dotenv(env_path)
+        print(f"[INFO] Loaded environment from {env_path}")
+
     python_exe = sys.executable
     commands = [
         [python_exe, "-m", "compileall", "app", "scripts"],
         [python_exe, "scripts/check_env_security.py", "--strict"],
-        [python_exe, "scripts/init_db.py"],
-        [python_exe, "scripts/retention_cleanup.py", "--dry-run"],
         [python_exe, "scripts/validate_risk_historical.py"],
     ]
-    if not args.skip_smoke:
+
+    if not args.skip_db:
+        commands.extend(
+            [
+                [python_exe, "scripts/init_db.py"],
+                [python_exe, "scripts/retention_cleanup.py", "--dry-run"],
+            ]
+        )
+    else:
+        print("[INFO] --skip-db enabled: skipping init_db and retention dry-run.")
+
+    if not args.skip_smoke and not args.skip_db:
         commands.append([python_exe, "scripts/smoke_db_flow.py"])
+    elif args.skip_smoke:
+        print("[INFO] --skip-smoke enabled: skipping smoke_db_flow.")
+    elif args.skip_db:
+        print("[INFO] --skip-db implies smoke_db_flow is skipped.")
+
     if args.base_url:
         commands.append([python_exe, "scripts/beta_preflight.py", "--base-url", args.base_url])
 

--- a/docs/cycle-aurora-calm-execution-plan.md
+++ b/docs/cycle-aurora-calm-execution-plan.md
@@ -365,6 +365,6 @@ Exit criteria:
 | 9     | partial     | 2026-05-01 |            | briefing SQL/service/API/script landed; dispatch dry-run blocked by local DB/env |
 | 10    | partial     | 2026-05-01 |            | settings toggle/time wired iOS+Android; device push proof pending |
 | 11    | partial     | 2026-05-01 |            | insights/settings empty+loading+error states polished; QA parity sweep pending |
-| 12    | blocked     | 2026-05-01 |            | full gate blocked locally (missing DB/JWT env + fastapi/pytest in system python) |
+| 12    | partial     | 2026-05-01 |            | pytest 32/32 + iOS/Android builds + `run_backend_gate.py --skip-db` green; DB-backed smoke/manual QA/demo pending |
 
 This table is updated after each stage gate.


### PR DESCRIPTION
## Summary
- add `--skip-db` and `--env-file` support to `backend/scripts/run_backend_gate.py` with explicit skip logging and `.env.local` preload
- add executable wrapper `backend/run_gate.sh` that auto-selects `backend/.venv`, then repo `.venv`, then falls back to `python3`
- document no-DB verification path in `backend/README.md` and update Stage 12 status wording in cycle execution plan

## Test plan
- [x] `backend/run_gate.sh --skip-db`
- [x] `backend/.venv/bin/python scripts/run_backend_gate.py --skip-db`
- [x] `backend/.venv/bin/python -m pytest -q`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `xcodebuild -project HiAir.xcodeproj -scheme HiAir -sdk iphonesimulator -configuration Debug build CODE_SIGNING_ALLOWED=NO`

Made with [Cursor](https://cursor.com)