### PR TITLE
Add machine-readable Stage 12 evidence collector

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -194,6 +194,13 @@ Shell wrapper (auto-picks `backend/.venv`, then repo-root `.venv`):
 ./run_gate.sh --skip-db
 ```
 
+Machine-readable Stage 12 evidence snapshot (writes JSON report under
+`docs/_operator/`):
+
+```bash
+.venv/bin/python scripts/collect_stage12_evidence.py --base-url http://127.0.0.1:8000 --skip-authenticated-checks
+```
+
 Apply retention cleanup (non-dry-run):
 
 ```bash

--- a/backend/scripts/collect_stage12_evidence.py
+++ b/backend/scripts/collect_stage12_evidence.py
@@ -1,0 +1,168 @@
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_ROOT = REPO_ROOT / "backend"
+
+
+@dataclass
+class EvidenceItem:
+    name: str
+    command: list[str]
+    cwd: str
+    status: str
+    exit_code: int
+    output_tail: str
+
+
+def _run_command(name: str, command: list[str], cwd: Path, allow_failure: bool = False) -> EvidenceItem:
+    completed = subprocess.run(command, cwd=cwd, check=False, capture_output=True, text=True)
+    combined_output = (completed.stdout or "") + ("\n" + completed.stderr if completed.stderr else "")
+    status = "DONE" if completed.returncode == 0 else "FAILED"
+
+    if completed.returncode != 0 and allow_failure:
+        lowered = combined_output.lower()
+        if "connection refused" in lowered or "database unavailable" in lowered:
+            status = "BLOCKED"
+
+    tail_lines = combined_output.strip().splitlines()
+    output_tail = "\n".join(tail_lines[-20:]) if tail_lines else ""
+
+    return EvidenceItem(
+        name=name,
+        command=_sanitize_command(command),
+        cwd=str(cwd),
+        status=status,
+        exit_code=completed.returncode,
+        output_tail=output_tail,
+    )
+
+
+def _sanitize_command(command: list[str]) -> list[str]:
+    sanitized = list(command)
+    for index, token in enumerate(sanitized):
+        if token == "--admin-token" and index + 1 < len(sanitized):
+            sanitized[index + 1] = "<redacted>"
+    return sanitized
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Collect machine-readable Stage 12 verification evidence.")
+    parser.add_argument(
+        "--output",
+        default=str(REPO_ROOT / "docs" / "_operator" / "stage12-evidence-latest.json"),
+        help="Path to JSON evidence output file.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Optional API base URL for running beta_preflight checks.",
+    )
+    parser.add_argument(
+        "--admin-token",
+        default=os.getenv("NOTIFICATION_ADMIN_TOKEN", ""),
+        help="Admin token for protected preflight endpoints.",
+    )
+    parser.add_argument(
+        "--skip-authenticated-checks",
+        action="store_true",
+        help="Pass through to beta_preflight for no-DB runs.",
+    )
+    args = parser.parse_args()
+
+    output_path = Path(args.output).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    items: list[EvidenceItem] = []
+    python_exe = sys.executable
+
+    items.append(
+        _run_command(
+            "pytest_full",
+            [python_exe, "-m", "pytest", "-q"],
+            cwd=BACKEND_ROOT,
+        )
+    )
+    items.append(
+        _run_command(
+            "run_backend_gate_skip_db",
+            [python_exe, "scripts/run_backend_gate.py", "--skip-db"],
+            cwd=BACKEND_ROOT,
+        )
+    )
+    items.append(
+        _run_command(
+            "run_backend_gate_full",
+            [python_exe, "scripts/run_backend_gate.py"],
+            cwd=BACKEND_ROOT,
+            allow_failure=True,
+        )
+    )
+    items.append(
+        _run_command(
+            "validate_risk_historical",
+            [python_exe, "scripts/validate_risk_historical.py"],
+            cwd=BACKEND_ROOT,
+        )
+    )
+
+    if args.base_url:
+        preflight_cmd = [python_exe, "scripts/beta_preflight.py", "--base-url", args.base_url]
+        if args.admin_token:
+            preflight_cmd.extend(["--admin-token", args.admin_token])
+        if args.skip_authenticated_checks:
+            preflight_cmd.append("--skip-authenticated-checks")
+        items.append(
+            _run_command(
+                "beta_preflight",
+                preflight_cmd,
+                cwd=BACKEND_ROOT,
+                allow_failure=True,
+            )
+        )
+
+    blocked = sum(1 for item in items if item.status == "BLOCKED")
+    failed = sum(1 for item in items if item.status == "FAILED")
+    done = sum(1 for item in items if item.status == "DONE")
+
+    summary = {
+        "collected_at_utc": datetime.now(tz=UTC).isoformat(),
+        "git_head": _git_head(),
+        "counts": {
+            "done": done,
+            "blocked": blocked,
+            "failed": failed,
+            "total": len(items),
+        },
+        "overall_status": "FAILED" if failed > 0 else ("PARTIAL" if blocked > 0 else "DONE"),
+        "items": [asdict(item) for item in items],
+    }
+    output_path.write_text(json.dumps(summary, ensure_ascii=True, indent=2), encoding="utf-8")
+    print(f"Wrote Stage 12 evidence: {output_path}")
+    print(f"Overall status: {summary['overall_status']}")
+
+    return 1 if failed > 0 else 0
+
+
+def _git_head() -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return "unknown"
+    return completed.stdout.strip()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/_operator/master-gap-report.md
+++ b/docs/_operator/master-gap-report.md
@@ -107,6 +107,8 @@ Second stabilization update:
 - **DONE**: automated privacy-export evidence for new surfaces in test suite
   (`test_privacy_export_api.py`) asserting `briefing_schedule` and
   `personal_correlations` payload presence.
+- **DONE**: latest machine-readable Stage 12 evidence snapshot published at
+  `docs/_operator/stage12-evidence-latest.json`.
 - **BLOCKED**: full DB-backed local smoke/evidence remains blocked on this machine
   (`localhost:5432` refused; Docker not installed), so privacy-export proof for new
   tables still needs a DB-capable environment.

--- a/docs/_operator/stage12-evidence-latest.json
+++ b/docs/_operator/stage12-evidence-latest.json
@@ -1,0 +1,76 @@
+{
+  "collected_at_utc": "2026-05-01T00:44:30.065544+00:00",
+  "git_head": "ce9e10040dddbc3531cb1018f6177c8e12b9ed0c",
+  "counts": {
+    "done": 4,
+    "blocked": 1,
+    "failed": 0,
+    "total": 5
+  },
+  "overall_status": "PARTIAL",
+  "items": [
+    {
+      "name": "pytest_full",
+      "command": [
+        "/Users/alex/Projects/HIAir/.venv/bin/python",
+        "-m",
+        "pytest",
+        "-q"
+      ],
+      "cwd": "/Users/alex/Projects/HIAir/backend",
+      "status": "DONE",
+      "exit_code": 0,
+      "output_tail": "..................................                                       [100%]\n34 passed in 2.15s"
+    },
+    {
+      "name": "run_backend_gate_skip_db",
+      "command": [
+        "/Users/alex/Projects/HIAir/.venv/bin/python",
+        "scripts/run_backend_gate.py",
+        "--skip-db"
+      ],
+      "cwd": "/Users/alex/Projects/HIAir/backend",
+      "status": "DONE",
+      "exit_code": 0,
+      "output_tail": "[OK] RETENTION_SUBSCRIPTION_WEBHOOK_EVENTS_DAYS=180.\n[OK] RETENTION_SECRET_ROTATION_EVENTS_DAYS=365.\nEnvironment security check passed.\npassed: True\ncases: 4/4\nheatwave_elderly: score=81 level=very_high expected_min=high passed=True\npollution_asthma: score=95 level=very_high expected_min=very_high passed=True\nmild_day_adult: score=14 level=low expected_min=low passed=True\nrunner_moderate_heat: score=47 level=medium expected_min=medium passed=True\n[INFO] Loaded environment from /Users/alex/Projects/HIAir/backend/.env.local\n[INFO] --skip-db enabled: skipping init_db and retention dry-run.\n[INFO] --skip-db implies smoke_db_flow is skipped.\n\n>>> Running: /Users/alex/Projects/HIAir/.venv/bin/python -m compileall app scripts\n\n>>> Running: /Users/alex/Projects/HIAir/.venv/bin/python scripts/check_env_security.py --strict\n\n>>> Running: /Users/alex/Projects/HIAir/.venv/bin/python scripts/validate_risk_historical.py\n\nBackend gate passed."
+    },
+    {
+      "name": "run_backend_gate_full",
+      "command": [
+        "/Users/alex/Projects/HIAir/.venv/bin/python",
+        "scripts/run_backend_gate.py"
+      ],
+      "cwd": "/Users/alex/Projects/HIAir/backend",
+      "status": "BLOCKED",
+      "exit_code": 1,
+      "output_tail": "\n>>> Running: /Users/alex/Projects/HIAir/.venv/bin/python scripts/init_db.py\nCommand failed with exit code 1: /Users/alex/Projects/HIAir/.venv/bin/python scripts/init_db.py\n\nTraceback (most recent call last):\n  File \"/Users/alex/Projects/HIAir/backend/scripts/init_db.py\", line 27, in <module>\n    main()\n    ~~~~^^\n  File \"/Users/alex/Projects/HIAir/backend/scripts/init_db.py\", line 17, in main\n    with connect(settings.database_url) as conn:\n         ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/alex/Projects/HIAir/.venv/lib/python3.14/site-packages/psycopg/connection.py\", line 130, in connect\n    raise new_ex.with_traceback(None)\npsycopg.OperationalError: connection failed: connection to server at \"::1\", port 5432 failed: Connection refused\n\tIs the server running on that host and accepting TCP/IP connections?\nMultiple connection attempts failed. All failures were:\n- host: 'localhost', port: '5432', hostaddr: '127.0.0.1': connection failed: connection to server at \"127.0.0.1\", port 5432 failed: Connection refused\n\tIs the server running on that host and accepting TCP/IP connections?\n- host: 'localhost', port: '5432', hostaddr: '::1': connection failed: connection to server at \"::1\", port 5432 failed: Connection refused\n\tIs the server running on that host and accepting TCP/IP connections?"
+    },
+    {
+      "name": "validate_risk_historical",
+      "command": [
+        "/Users/alex/Projects/HIAir/.venv/bin/python",
+        "scripts/validate_risk_historical.py"
+      ],
+      "cwd": "/Users/alex/Projects/HIAir/backend",
+      "status": "DONE",
+      "exit_code": 0,
+      "output_tail": "passed: True\ncases: 4/4\nheatwave_elderly: score=81 level=very_high expected_min=high passed=True\npollution_asthma: score=95 level=very_high expected_min=very_high passed=True\nmild_day_adult: score=14 level=low expected_min=low passed=True\nrunner_moderate_heat: score=47 level=medium expected_min=medium passed=True"
+    },
+    {
+      "name": "beta_preflight",
+      "command": [
+        "/Users/alex/Projects/HIAir/.venv/bin/python",
+        "scripts/beta_preflight.py",
+        "--base-url",
+        "http://127.0.0.1:8000",
+        "--admin-token",
+        "<redacted>",
+        "--skip-authenticated-checks"
+      ],
+      "cwd": "/Users/alex/Projects/HIAir/backend",
+      "status": "DONE",
+      "exit_code": 0,
+      "output_tail": "[OK] /api/health\n[OK] /api/notifications/provider-health\n[OK] /api/notifications/secret-store-health\n[OK] /api/notifications/credentials-health\n[OK] /api/observability/metrics\n[OK] /api/validation/risk/historical\nSkipping authenticated checks (--skip-authenticated-checks).\nPreflight passed."
+    }
+  ]
+}

--- a/docs/cycle-aurora-calm-execution-plan.md
+++ b/docs/cycle-aurora-calm-execution-plan.md
@@ -377,6 +377,9 @@ Current local gate status:
 - **DONE**: `backend/run_gate.sh --skip-db` and `backend/scripts/run_backend_gate.py --skip-db`.
 - **BLOCKED**: full `backend/run_gate.sh` (without `--skip-db`) due to unavailable local Postgres.
 - **DONE**: local preflight infrastructure checks against live API with `--skip-authenticated-checks`.
+- **DONE**: machine-readable evidence snapshot generated at
+  `docs/_operator/stage12-evidence-latest.json` via
+  `backend/scripts/collect_stage12_evidence.py`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add `backend/scripts/collect_stage12_evidence.py` to produce a machine-readable Stage 12 verification snapshot with `DONE/BLOCKED/FAILED` items and command output tails
- publish latest generated artifact at `docs/_operator/stage12-evidence-latest.json`
- document the collector command in `backend/README.md` and link the artifact path from cycle/operator tracking docs

## Test plan
- [x] `cd backend && ../.venv/bin/python -m pytest tests/test_notification_credentials.py tests/test_privacy_export_api.py -q`
- [x] `cd backend && ../.venv/bin/python scripts/collect_stage12_evidence.py --base-url http://127.0.0.1:8000 --skip-authenticated-checks` (with local API running)

Made with [Cursor](https://cursor.com)