### PR TITLE
Fix DB-backed smoke bytes decoding and refresh evidence

### DIFF
--- a/backend/app/services/air_repository.py
+++ b/backend/app/services/air_repository.py
@@ -53,23 +53,32 @@ def get_profile_context(profile_id: str) -> UserProfileContext | None:
     if row is None:
         return None
 
-    profile_type = row["profile_type"]
+    profile_type = _as_text(row["profile_type"])
+    persona_type = _as_text(row["persona_type"])
     if not profile_type:
-        profile_type = PERSONA_TO_PROFILE_TYPE.get(row["persona_type"], ProfileType.ADULT_DEFAULT).value
+        profile_type = PERSONA_TO_PROFILE_TYPE.get(persona_type, ProfileType.ADULT_DEFAULT).value
 
     return UserProfileContext(
         profile_id=str(row["id"]),
         user_id=str(row["user_id"]),
         profile_type=ProfileType(profile_type),
-        age_group=row["age_group"] or "adult",
+        age_group=_as_text(row["age_group"]) or "adult",
         heat_sensitivity_level=int(row["heat_sensitivity_level"] or 2),
         respiratory_sensitivity_level=int(row["respiratory_sensitivity_level"] or 2),
-        activity_level=row["activity_level"] or "moderate",
-        location_name=row["location_name"],
-        timezone=row["timezone"] or "UTC",
+        activity_level=_as_text(row["activity_level"]) or "moderate",
+        location_name=_as_text(row["location_name"]),
+        timezone=_as_text(row["timezone"]) or "UTC",
         home_lat=float(row["home_lat"]),
         home_lon=float(row["home_lon"]),
     )
+
+
+def _as_text(value: object | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode("utf-8")
+    return str(value)
 
 
 def save_environment_snapshot(environment: EnvironmentalInput) -> str:

--- a/backend/tests/test_air_repository_serialization.py
+++ b/backend/tests/test_air_repository_serialization.py
@@ -1,0 +1,7 @@
+from app.services.air_repository import _as_text
+
+
+def test_as_text_decodes_bytes_values() -> None:
+    assert _as_text(b"adult_default") == "adult_default"
+    assert _as_text(bytearray(b"Europe/Madrid")) == "Europe/Madrid"
+    assert _as_text("runner") == "runner"

--- a/docs/_operator/master-gap-report.md
+++ b/docs/_operator/master-gap-report.md
@@ -109,9 +109,9 @@ Second stabilization update:
   `personal_correlations` payload presence.
 - **DONE**: latest machine-readable Stage 12 evidence snapshot published at
   `docs/_operator/stage12-evidence-latest.json`.
-- **BLOCKED**: full DB-backed local smoke/evidence remains blocked on this machine
-  (`localhost:5432` refused; Docker not installed), so privacy-export proof for new
-  tables still needs a DB-capable environment.
+- **DONE**: DB-backed local smoke/evidence verified by running full backend gate and
+  smoke flow against temporary local Postgres (`127.0.0.1:55432`), including
+  privacy export and new insights/briefings endpoints.
 - **MISSING**: manual device QA packet completion and demo video artifact.
 ### Cycle exit will close
 - Documentation drift: design system now has a code-level SoT and on-platform

--- a/docs/_operator/stage12-evidence-latest.json
+++ b/docs/_operator/stage12-evidence-latest.json
@@ -1,13 +1,13 @@
 {
-  "collected_at_utc": "2026-05-01T00:44:30.065544+00:00",
-  "git_head": "ce9e10040dddbc3531cb1018f6177c8e12b9ed0c",
+  "collected_at_utc": "2026-05-01T00:52:07.392951+00:00",
+  "git_head": "7e582ca77b3d9a39c42ae3c12be649524950a26d",
   "counts": {
-    "done": 4,
-    "blocked": 1,
+    "done": 5,
+    "blocked": 0,
     "failed": 0,
     "total": 5
   },
-  "overall_status": "PARTIAL",
+  "overall_status": "DONE",
   "items": [
     {
       "name": "pytest_full",
@@ -20,7 +20,7 @@
       "cwd": "/Users/alex/Projects/HIAir/backend",
       "status": "DONE",
       "exit_code": 0,
-      "output_tail": "..................................                                       [100%]\n34 passed in 2.15s"
+      "output_tail": "...................................                                      [100%]\n35 passed in 1.41s"
     },
     {
       "name": "run_backend_gate_skip_db",
@@ -41,9 +41,9 @@
         "scripts/run_backend_gate.py"
       ],
       "cwd": "/Users/alex/Projects/HIAir/backend",
-      "status": "BLOCKED",
-      "exit_code": 1,
-      "output_tail": "\n>>> Running: /Users/alex/Projects/HIAir/.venv/bin/python scripts/init_db.py\nCommand failed with exit code 1: /Users/alex/Projects/HIAir/.venv/bin/python scripts/init_db.py\n\nTraceback (most recent call last):\n  File \"/Users/alex/Projects/HIAir/backend/scripts/init_db.py\", line 27, in <module>\n    main()\n    ~~~~^^\n  File \"/Users/alex/Projects/HIAir/backend/scripts/init_db.py\", line 17, in main\n    with connect(settings.database_url) as conn:\n         ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/alex/Projects/HIAir/.venv/lib/python3.14/site-packages/psycopg/connection.py\", line 130, in connect\n    raise new_ex.with_traceback(None)\npsycopg.OperationalError: connection failed: connection to server at \"::1\", port 5432 failed: Connection refused\n\tIs the server running on that host and accepting TCP/IP connections?\nMultiple connection attempts failed. All failures were:\n- host: 'localhost', port: '5432', hostaddr: '127.0.0.1': connection failed: connection to server at \"127.0.0.1\", port 5432 failed: Connection refused\n\tIs the server running on that host and accepting TCP/IP connections?\n- host: 'localhost', port: '5432', hostaddr: '::1': connection failed: connection to server at \"::1\", port 5432 failed: Connection refused\n\tIs the server running on that host and accepting TCP/IP connections?"
+      "status": "DONE",
+      "exit_code": 0,
+      "output_tail": "INFO:hiair.api:{\"request_id\": \"647121aa-9849-43b0-8f6e-e5e9381333c8\", \"method\": \"GET\", \"path\": \"/api/planner/daily\", \"status_code\": 200, \"latency_ms\": 2.48}\nINFO:httpx:HTTP Request: GET http://testserver/api/planner/daily?persona=asthma&lat=41.39&lon=2.17&hours=12 \"HTTP/1.1 200 OK\"\nINFO:hiair.api:{\"request_id\": \"8e9f5ad2-f0a9-487b-a8ce-f58b84867825\", \"method\": \"GET\", \"path\": \"/api/insights/personal-patterns\", \"status_code\": 200, \"latency_ms\": 33.69}\nINFO:httpx:HTTP Request: GET http://testserver/api/insights/personal-patterns?profile_id=d8a231df-1a7f-4391-9c10-fa5e97ffdff1&window_days=30&language=en \"HTTP/1.1 200 OK\"\nINFO:hiair.api:{\"request_id\": \"6ad6a9c0-08b9-4ea8-9a45-07c29940bb83\", \"method\": \"GET\", \"path\": \"/api/validation/risk/historical\", \"status_code\": 200, \"latency_ms\": 1.54}\nINFO:httpx:HTTP Request: GET http://testserver/api/validation/risk/historical \"HTTP/1.1 200 OK\"\nINFO:hiair.api:{\"request_id\": \"367bca44-02b3-41b0-baba-ee2faea783e5\", \"method\": \"GET\", \"path\": \"/api/observability/metrics\", \"status_code\": 200, \"latency_ms\": 1.65}\nINFO:httpx:HTTP Request: GET http://testserver/api/observability/metrics \"HTTP/1.1 200 OK\"\nINFO:hiair.api:{\"request_id\": \"330b1fb8-c677-46d2-b087-d0990e1ce5e9\", \"method\": \"POST\", \"path\": \"/api/auth/signup\", \"status_code\": 200, \"latency_ms\": 64.01}\nINFO:httpx:HTTP Request: POST http://testserver/api/auth/signup \"HTTP/1.1 200 OK\"\nINFO:hiair.api:{\"request_id\": \"2a7e5748-9cab-4885-b71e-ee8e6542e45f\", \"method\": \"GET\", \"path\": \"/api/risk/history\", \"status_code\": 403, \"latency_ms\": 19.88}\nINFO:httpx:HTTP Request: GET http://testserver/api/risk/history?profile_id=d8a231df-1a7f-4391-9c10-fa5e97ffdff1&limit=5 \"HTTP/1.1 403 Forbidden\"\nINFO:hiair.api:{\"request_id\": \"c2a8fe80-a0e4-4767-b2f5-708911bbfe8e\", \"method\": \"GET\", \"path\": \"/api/privacy/export\", \"status_code\": 200, \"latency_ms\": 24.96}\nINFO:httpx:HTTP Request: GET http://testserver/api/privacy/export \"HTTP/1.1 200 OK\"\nINFO:hiair.api:{\"request_id\": \"5ec08e66-e55b-4f19-9996-0d3708367207\", \"method\": \"POST\", \"path\": \"/api/privacy/delete-account\", \"status_code\": 200, \"latency_ms\": 21.21}\nINFO:httpx:HTTP Request: POST http://testserver/api/privacy/delete-account \"HTTP/1.1 200 OK\"\nINFO:hiair.api:{\"request_id\": \"e855c9d4-b5b6-492c-ada9-eb9f8c001586\", \"method\": \"POST\", \"path\": \"/api/auth/login\", \"status_code\": 401, \"latency_ms\": 7.02}\nINFO:httpx:HTTP Request: POST http://testserver/api/auth/login \"HTTP/1.1 401 Unauthorized\"\nINFO:hiair.api:{\"request_id\": \"c552e8de-dc5a-4c80-b919-bbc50d70d313\", \"method\": \"GET\", \"path\": \"/api/auth/me\", \"status_code\": 401, \"latency_ms\": 7.04}\nINFO:httpx:HTTP Request: GET http://testserver/api/auth/me \"HTTP/1.1 401 Unauthorized\""
     },
     {
       "name": "validate_risk_historical",
@@ -64,13 +64,12 @@
         "--base-url",
         "http://127.0.0.1:8000",
         "--admin-token",
-        "<redacted>",
-        "--skip-authenticated-checks"
+        "<redacted>"
       ],
       "cwd": "/Users/alex/Projects/HIAir/backend",
       "status": "DONE",
       "exit_code": 0,
-      "output_tail": "[OK] /api/health\n[OK] /api/notifications/provider-health\n[OK] /api/notifications/secret-store-health\n[OK] /api/notifications/credentials-health\n[OK] /api/observability/metrics\n[OK] /api/validation/risk/historical\nSkipping authenticated checks (--skip-authenticated-checks).\nPreflight passed."
+      "output_tail": "[OK] /api/health\n[OK] /api/notifications/provider-health\n[OK] /api/notifications/secret-store-health\n[OK] /api/notifications/credentials-health\n[OK] /api/observability/metrics\n[OK] /api/validation/risk/historical\n[OK] /api/auth/signup\n[OK] /api/profiles\n[OK] /api/subscriptions/activate\n[OK] /api/recommendations/daily\n[OK] /api/briefings/schedule\n[OK] /api/insights/personal-patterns\n[OK] /api/privacy/export\n[OK] ownership guard /api/risk/history\nPreflight passed."
     }
   ]
 }

--- a/docs/cycle-aurora-calm-execution-plan.md
+++ b/docs/cycle-aurora-calm-execution-plan.md
@@ -364,19 +364,20 @@ Exit criteria:
    `../.venv/bin/python scripts/beta_preflight.py --base-url http://127.0.0.1:8000 --admin-token "$NOTIFICATION_ADMIN_TOKEN" --skip-authenticated-checks`.
 7. Manual QA per updated `docs/qa-checklist.md` — **PARTIAL**  
    Evidence: checklist expanded with Insights/Briefing items; full device run not yet attached.
-8. `docs/_operator/master-gap-report.md` updated with cycle outcome — **PARTIAL**  
-   Evidence: cycle statuses moved from planned to done/in_progress/partial; final closure pass still pending.
+8. `docs/_operator/master-gap-report.md` updated with cycle outcome — **DONE**  
+   Evidence: cycle status and verification snapshot sections updated with merge-era evidence.
 9. `docs/release-notes-aurora-calm.md` written — **DONE**  
    Evidence: release notes file created and merged.
-10. Privacy export evidence saved on test account with patterns + briefing — **BLOCKED**  
-    Blocker: local Postgres unavailable (`localhost:5432 connection refused`), cannot complete DB-backed proof run locally.
+10. Privacy export evidence saved on test account with patterns + briefing — **DONE**  
+    Evidence: full DB-backed `scripts/smoke_db_flow.py` passed against temporary local Postgres, including
+    `/api/privacy/export`, `/api/insights/personal-patterns`, and `/api/briefings/schedule` assertions.
 11. Demo video recorded — **MISSING**  
     Blocker: manual artifact pending.
 
 Current local gate status:
 - **DONE**: `backend/run_gate.sh --skip-db` and `backend/scripts/run_backend_gate.py --skip-db`.
-- **BLOCKED**: full `backend/run_gate.sh` (without `--skip-db`) due to unavailable local Postgres.
-- **DONE**: local preflight infrastructure checks against live API with `--skip-authenticated-checks`.
+- **DONE**: full `backend/scripts/run_backend_gate.py` against temporary local Postgres (`127.0.0.1:55432`).
+- **DONE**: full preflight (including authenticated checks) against live API with temporary local Postgres.
 - **DONE**: machine-readable evidence snapshot generated at
   `docs/_operator/stage12-evidence-latest.json` via
   `backend/scripts/collect_stage12_evidence.py`.
@@ -399,6 +400,6 @@ Current local gate status:
 | 9     | partial     | 2026-05-01 |            | briefing SQL/service/API/script landed; dispatch dry-run blocked by local DB/env |
 | 10    | partial     | 2026-05-01 |            | settings toggle/time wired iOS+Android; device push proof pending |
 | 11    | partial     | 2026-05-01 |            | insights/settings empty+loading+error states polished; QA parity sweep pending |
-| 12    | partial     | 2026-05-01 |            | pytest 32/32 + iOS/Android builds + `run_backend_gate.py --skip-db` green; DB-backed smoke/manual QA/demo pending |
+| 12    | partial     | 2026-05-01 |            | machine evidence DONE (full gate + smoke + preflight + CI/builds); remaining manual QA + demo video |
 
 This table is updated after each stage gate.


### PR DESCRIPTION
## Summary
- fix `air_repository.get_profile_context` to normalize byte-encoded profile fields from Postgres before enum/string mapping
- add regression test `test_air_repository_serialization.py` for bytes decoding behavior
- refresh Stage 12 evidence/docs after successful DB-backed full gate run (temporary local Postgres), removing local DB blocker status from cycle/operator snapshots

## Test plan
- [x] `cd backend && ../.venv/bin/python -m pytest -q`
- [x] `cd mobile/android && ./gradlew :app:compileDebugKotlin`
- [x] `cd mobile/ios && xcodebuild -project HiAir.xcodeproj -scheme HiAir -sdk iphonesimulator -configuration Debug build CODE_SIGNING_ALLOWED=NO`
- [x] `DATABASE_URL=postgresql://hiair@127.0.0.1:55432/hiair ../.venv/bin/python backend/scripts/run_backend_gate.py` (with temp local Postgres)
- [x] full `beta_preflight.py` authenticated run against local API backed by temp Postgres

Made with [Cursor](https://cursor.com)