### PR TITLE
Add Stage 12 closure packet generator

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -201,6 +201,12 @@ Machine-readable Stage 12 evidence snapshot (writes JSON report under
 .venv/bin/python scripts/collect_stage12_evidence.py --base-url http://127.0.0.1:8000 --skip-authenticated-checks
 ```
 
+Generate Stage 12 closure packet markdown from the latest JSON evidence:
+
+```bash
+.venv/bin/python scripts/generate_stage12_closure_packet.py
+```
+
 Apply retention cleanup (non-dry-run):
 
 ```bash

--- a/backend/scripts/generate_stage12_closure_packet.py
+++ b/backend/scripts/generate_stage12_closure_packet.py
@@ -1,0 +1,96 @@
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_EVIDENCE_JSON = REPO_ROOT / "docs" / "_operator" / "stage12-evidence-latest.json"
+DEFAULT_OUTPUT_MD = REPO_ROOT / "docs" / "_operator" / "stage12-closure-packet.md"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate Stage 12 closure packet markdown from evidence JSON.")
+    parser.add_argument(
+        "--evidence-json",
+        default=str(DEFAULT_EVIDENCE_JSON),
+        help="Path to stage12 evidence JSON file.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(DEFAULT_OUTPUT_MD),
+        help="Path to output markdown packet.",
+    )
+    args = parser.parse_args()
+
+    evidence_path = Path(args.evidence_json).expanduser()
+    output_path = Path(args.output).expanduser()
+
+    if not evidence_path.exists():
+        raise SystemExit(f"Evidence file not found: {evidence_path}")
+
+    payload = json.loads(evidence_path.read_text(encoding="utf-8"))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(_render(payload), encoding="utf-8")
+    print(f"Wrote Stage 12 closure packet: {output_path}")
+    return 0
+
+
+def _render(payload: dict) -> str:
+    collected_at = payload.get("collected_at_utc", "unknown")
+    git_head = payload.get("git_head", "unknown")
+    overall_status = payload.get("overall_status", "unknown")
+    counts = payload.get("counts", {})
+    items = payload.get("items", [])
+
+    lines: list[str] = []
+    lines.append("# Stage 12 Closure Packet")
+    lines.append("")
+    lines.append(f"Generated at (UTC): {datetime.now(tz=UTC).isoformat()}")
+    lines.append(f"Evidence collected at (UTC): {collected_at}")
+    lines.append(f"Git HEAD: `{git_head}`")
+    lines.append("")
+    lines.append("## Automated Verification Summary")
+    lines.append("")
+    lines.append(f"- Overall status: **{overall_status}**")
+    lines.append(f"- Done: `{counts.get('done', 0)}`")
+    lines.append(f"- Blocked: `{counts.get('blocked', 0)}`")
+    lines.append(f"- Failed: `{counts.get('failed', 0)}`")
+    lines.append(f"- Total checks: `{counts.get('total', 0)}`")
+    lines.append("")
+    lines.append("| Check | Status | Exit Code |")
+    lines.append("|---|---|---:|")
+    for item in items:
+        lines.append(
+            f"| `{item.get('name', '-')}` | `{item.get('status', '-')}` | `{item.get('exit_code', '-')}` |"
+        )
+    lines.append("")
+    lines.append("## Evidence Source")
+    lines.append("")
+    lines.append("- Machine-readable evidence JSON:")
+    lines.append(f"  - `{_relative_path(DEFAULT_EVIDENCE_JSON)}`")
+    lines.append("")
+    lines.append("## Remaining Manual Artifacts")
+    lines.append("")
+    lines.append("- [ ] Device QA packet attached (fill report path)")
+    lines.append("  - Suggested artifact: `docs/qa-run-007-report.md`")
+    lines.append("- [ ] Demo video attached (fill link/path)")
+    lines.append("  - Suggested artifact: `docs/_operator/stage12-demo-video-link.md`")
+    lines.append("")
+    lines.append("## Reviewer Notes")
+    lines.append("")
+    lines.append("- This packet is generated automatically from the latest Stage 12 evidence JSON.")
+    lines.append("- Manual artifacts remain explicit checkboxes to prevent false closure.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _relative_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(path)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/_operator/stage12-closure-packet.md
+++ b/docs/_operator/stage12-closure-packet.md
@@ -1,0 +1,38 @@
+# Stage 12 Closure Packet
+
+Generated at (UTC): 2026-05-01T01:01:03.192602+00:00
+Evidence collected at (UTC): 2026-05-01T00:52:07.392951+00:00
+Git HEAD: `7e582ca77b3d9a39c42ae3c12be649524950a26d`
+
+## Automated Verification Summary
+
+- Overall status: **DONE**
+- Done: `5`
+- Blocked: `0`
+- Failed: `0`
+- Total checks: `5`
+
+| Check | Status | Exit Code |
+|---|---|---:|
+| `pytest_full` | `DONE` | `0` |
+| `run_backend_gate_skip_db` | `DONE` | `0` |
+| `run_backend_gate_full` | `DONE` | `0` |
+| `validate_risk_historical` | `DONE` | `0` |
+| `beta_preflight` | `DONE` | `0` |
+
+## Evidence Source
+
+- Machine-readable evidence JSON:
+  - `docs/_operator/stage12-evidence-latest.json`
+
+## Remaining Manual Artifacts
+
+- [ ] Device QA packet attached (fill report path)
+  - Suggested artifact: `docs/qa-run-007-report.md`
+- [ ] Demo video attached (fill link/path)
+  - Suggested artifact: `docs/_operator/stage12-demo-video-link.md`
+
+## Reviewer Notes
+
+- This packet is generated automatically from the latest Stage 12 evidence JSON.
+- Manual artifacts remain explicit checkboxes to prevent false closure.


### PR DESCRIPTION
## Summary
- add `backend/scripts/generate_stage12_closure_packet.py` to build a reviewer-facing Stage 12 closure markdown packet from the latest machine evidence JSON
- add generated artifact `docs/_operator/stage12-closure-packet.md` with explicit manual checkboxes for device QA and demo video
- document closure packet generation command in `backend/README.md`

## Test plan
- [x] `../.venv/bin/python -m compileall backend/scripts`
- [x] `../.venv/bin/python backend/scripts/generate_stage12_closure_packet.py`

Made with [Cursor](https://cursor.com)