### PR TITLE
Add Stage 12 closure readiness checker

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -207,6 +207,12 @@ Generate Stage 12 closure packet markdown from the latest JSON evidence:
 .venv/bin/python scripts/generate_stage12_closure_packet.py
 ```
 
+Check Stage 12 closure readiness (expects both manual artifacts completed):
+
+```bash
+.venv/bin/python scripts/check_stage12_closure_readiness.py --json-output ../docs/_operator/stage12-closure-readiness.json
+```
+
 Apply retention cleanup (non-dry-run):
 
 ```bash

--- a/backend/scripts/check_stage12_closure_readiness.py
+++ b/backend/scripts/check_stage12_closure_readiness.py
@@ -1,0 +1,115 @@
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CLOSURE_PACKET = REPO_ROOT / "docs" / "_operator" / "stage12-closure-packet.md"
+DEFAULT_QA_REPORT = REPO_ROOT / "docs" / "qa-run-007-report.md"
+DEFAULT_DEMO_LINK = REPO_ROOT / "docs" / "_operator" / "stage12-demo-video-link.md"
+DEFAULT_EVIDENCE_JSON = REPO_ROOT / "docs" / "_operator" / "stage12-evidence-latest.json"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check whether Stage 12 closure packet is fully ready.")
+    parser.add_argument("--json-output", default=None, help="Optional path to write machine-readable readiness JSON.")
+    args = parser.parse_args()
+
+    checks = [
+        _exists_check("closure_packet_exists", DEFAULT_CLOSURE_PACKET),
+        _exists_check("qa_report_exists", DEFAULT_QA_REPORT),
+        _exists_check("demo_link_file_exists", DEFAULT_DEMO_LINK),
+        _exists_check("evidence_json_exists", DEFAULT_EVIDENCE_JSON),
+        _evidence_status_check(),
+        _closure_checkbox_check(),
+        _demo_link_filled_check(),
+    ]
+
+    all_ready = all(item["status"] == "READY" for item in checks)
+    report = {
+        "stage": "stage12-closure",
+        "all_ready": all_ready,
+        "checks": checks,
+    }
+
+    for item in checks:
+        print(f"[{item['status']}] {item['name']}: {item['detail']}")
+    print("Stage 12 closure readiness:", "READY" if all_ready else "NOT_READY")
+
+    if args.json_output:
+        path = Path(args.json_output).expanduser()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(report, ensure_ascii=True, indent=2), encoding="utf-8")
+        print(f"Wrote readiness JSON: {path}")
+
+    return 0 if all_ready else 1
+
+
+def _exists_check(name: str, path: Path) -> dict[str, str]:
+    exists = path.exists()
+    return {
+        "name": name,
+        "status": "READY" if exists else "NOT_READY",
+        "detail": f"{path} {'exists' if exists else 'is missing'}",
+    }
+
+
+def _evidence_status_check() -> dict[str, str]:
+    if not DEFAULT_EVIDENCE_JSON.exists():
+        return {
+            "name": "evidence_json_overall_status",
+            "status": "NOT_READY",
+            "detail": f"{DEFAULT_EVIDENCE_JSON} is missing",
+        }
+    payload = json.loads(DEFAULT_EVIDENCE_JSON.read_text(encoding="utf-8"))
+    status = payload.get("overall_status")
+    return {
+        "name": "evidence_json_overall_status",
+        "status": "READY" if status == "DONE" else "NOT_READY",
+        "detail": f"overall_status={status}",
+    }
+
+
+def _closure_checkbox_check() -> dict[str, str]:
+    if not DEFAULT_CLOSURE_PACKET.exists():
+        return {
+            "name": "closure_packet_manual_checkboxes",
+            "status": "NOT_READY",
+            "detail": f"{DEFAULT_CLOSURE_PACKET} is missing",
+        }
+    content = DEFAULT_CLOSURE_PACKET.read_text(encoding="utf-8")
+    device_checked = re.search(r"- \[x\] Device QA packet attached", content) is not None
+    demo_checked = re.search(r"- \[x\] Demo video attached", content) is not None
+    ready = device_checked and demo_checked
+    return {
+        "name": "closure_packet_manual_checkboxes",
+        "status": "READY" if ready else "NOT_READY",
+        "detail": f"device_checked={device_checked}, demo_checked={demo_checked}",
+    }
+
+
+def _demo_link_filled_check() -> dict[str, str]:
+    if not DEFAULT_DEMO_LINK.exists():
+        return {
+            "name": "demo_video_link_content",
+            "status": "NOT_READY",
+            "detail": f"{DEFAULT_DEMO_LINK} is missing",
+        }
+    content = DEFAULT_DEMO_LINK.read_text(encoding="utf-8")
+    pending_markers = [
+        "pending manual recording",
+        "replace this file content",
+    ]
+    has_pending_marker = any(marker in content.lower() for marker in pending_markers)
+    has_url = bool(re.search(r"https?://", content))
+    ready = has_url and not has_pending_marker
+    return {
+        "name": "demo_video_link_content",
+        "status": "READY" if ready else "NOT_READY",
+        "detail": f"has_url={has_url}, has_pending_marker={has_pending_marker}",
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/_operator/stage12-closure-readiness.json
+++ b/docs/_operator/stage12-closure-readiness.json
@@ -1,0 +1,41 @@
+{
+  "stage": "stage12-closure",
+  "all_ready": false,
+  "checks": [
+    {
+      "name": "closure_packet_exists",
+      "status": "READY",
+      "detail": "/Users/alex/Projects/HIAir/docs/_operator/stage12-closure-packet.md exists"
+    },
+    {
+      "name": "qa_report_exists",
+      "status": "READY",
+      "detail": "/Users/alex/Projects/HIAir/docs/qa-run-007-report.md exists"
+    },
+    {
+      "name": "demo_link_file_exists",
+      "status": "READY",
+      "detail": "/Users/alex/Projects/HIAir/docs/_operator/stage12-demo-video-link.md exists"
+    },
+    {
+      "name": "evidence_json_exists",
+      "status": "READY",
+      "detail": "/Users/alex/Projects/HIAir/docs/_operator/stage12-evidence-latest.json exists"
+    },
+    {
+      "name": "evidence_json_overall_status",
+      "status": "READY",
+      "detail": "overall_status=DONE"
+    },
+    {
+      "name": "closure_packet_manual_checkboxes",
+      "status": "NOT_READY",
+      "detail": "device_checked=True, demo_checked=False"
+    },
+    {
+      "name": "demo_video_link_content",
+      "status": "NOT_READY",
+      "detail": "has_url=False, has_pending_marker=True"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `backend/scripts/check_stage12_closure_readiness.py` to validate final Stage 12 closure criteria from artifacts
- emit machine-readable status at `docs/_operator/stage12-closure-readiness.json`
- document the checker command in `backend/README.md`

## Test plan
- [x] `../.venv/bin/python -m compileall backend/scripts`
- [x] `../.venv/bin/python backend/scripts/check_stage12_closure_readiness.py --json-output docs/_operator/stage12-closure-readiness.json`

Made with [Cursor](https://cursor.com)