### PR TITLE
Add Stage 12 demo recorder helper and blocker notes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -213,6 +213,12 @@ Check Stage 12 closure readiness (expects both manual artifacts completed):
 .venv/bin/python scripts/check_stage12_closure_readiness.py --json-output ../docs/_operator/stage12-closure-readiness.json
 ```
 
+iOS demo recording helper (requires a healthy bootable Simulator runtime):
+
+```bash
+scripts/record_stage12_demo_ios.sh
+```
+
 Apply retention cleanup (non-dry-run):
 
 ```bash

--- a/backend/scripts/record_stage12_demo_ios.sh
+++ b/backend/scripts/record_stage12_demo_ios.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IOS_ROOT="${REPO_ROOT}/mobile/ios"
+SIM_UDID="${SIM_UDID:-2D996686-433A-43B0-BFD3-0954C72B65B9}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-/tmp/hiair-demo-dd}"
+OUTPUT_PATH="${OUTPUT_PATH:-${REPO_ROOT}/docs/_operator/stage12-demo-ios.mp4}"
+RECORD_SECONDS="${RECORD_SECONDS:-20}"
+APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.hiair.app}"
+
+echo "[INFO] Using simulator: ${SIM_UDID}"
+echo "[INFO] Output video: ${OUTPUT_PATH}"
+
+open -a Simulator
+sleep 2
+xcrun simctl boot "${SIM_UDID}" || true
+xcrun simctl bootstatus "${SIM_UDID}" -b
+
+xcodebuild \
+  -project "${IOS_ROOT}/HiAir.xcodeproj" \
+  -scheme "HiAir" \
+  -sdk iphonesimulator \
+  -configuration Debug \
+  -destination "id=${SIM_UDID}" \
+  -derivedDataPath "${DERIVED_DATA_PATH}" \
+  build \
+  CODE_SIGNING_ALLOWED=NO
+
+APP_PATH="${DERIVED_DATA_PATH}/Build/Products/Debug-iphonesimulator/HiAir.app"
+if [[ ! -d "${APP_PATH}" ]]; then
+  echo "[ERROR] App bundle not found at ${APP_PATH}"
+  exit 1
+fi
+
+xcrun simctl install "${SIM_UDID}" "${APP_PATH}"
+xcrun simctl launch "${SIM_UDID}" "${APP_BUNDLE_ID}"
+
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+rm -f "${OUTPUT_PATH}"
+
+echo "[INFO] Recording for ${RECORD_SECONDS}s..."
+xcrun simctl io "${SIM_UDID}" recordVideo "${OUTPUT_PATH}" &
+REC_PID=$!
+sleep "${RECORD_SECONDS}"
+kill -INT "${REC_PID}" || true
+wait "${REC_PID}" || true
+
+if [[ ! -f "${OUTPUT_PATH}" ]]; then
+  echo "[ERROR] Recording file not created: ${OUTPUT_PATH}"
+  exit 1
+fi
+
+echo "[OK] Demo recording saved: ${OUTPUT_PATH}"

--- a/docs/_operator/stage12-closure-readiness.json
+++ b/docs/_operator/stage12-closure-readiness.json
@@ -35,7 +35,7 @@
     {
       "name": "demo_video_link_content",
       "status": "NOT_READY",
-      "detail": "has_url=False, has_pending_marker=True"
+      "detail": "has_url=False, has_pending_marker=False"
     }
   ]
 }

--- a/docs/_operator/stage12-demo-video-link.md
+++ b/docs/_operator/stage12-demo-video-link.md
@@ -1,11 +1,30 @@
 # Stage 12 Demo Video Link
 
-Status: pending manual recording.
+Status: blocked on local simulator runtime.
 
-When available, replace this file content with:
+## Attempt log (automated)
+
+- 2026-05-01 UTC: attempted iOS simulator recording via `simctl`.
+- Failure: `Unable to boot the Simulator. launchd failed to respond.`
+- Underlying error: `Failed to start launchd_sim: could not bind to session`.
+
+## Recorder helper
+
+- Script: `backend/scripts/record_stage12_demo_ios.sh`
+- Expected output path: `docs/_operator/stage12-demo-ios.mp4`
+
+## To finalize this artifact
+
+Run on a machine where iOS Simulator can boot:
+
+```bash
+backend/scripts/record_stage12_demo_ios.sh
+```
+
+Then replace this file with:
 
 - recording date/time (UTC)
 - owner
-- storage link (Drive/S3/etc.)
+- storage link/path
 - checksum or immutable reference
 - short note listing covered flows (Dashboard, Planner, Symptoms, Insights, Settings/Briefings)


### PR DESCRIPTION
## Summary
- add `backend/scripts/record_stage12_demo_ios.sh` to automate iOS simulator demo capture (`simctl boot/build/install/launch/recordVideo`)
- update demo artifact placeholder with concrete failure evidence from current host (`launchd_sim` boot failure) and exact finalize command
- refresh closure readiness JSON after blocker status update and document helper command in backend README

## Test plan
- [x] `backend/scripts/check_stage12_closure_readiness.py --json-output docs/_operator/stage12-closure-readiness.json`
- [x] Script exists and is executable: `backend/scripts/record_stage12_demo_ios.sh`

Made with [Cursor](https://cursor.com)