### PR TITLE
Add Android Play Store release automation

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,6 +28,9 @@ jobs:
           java-version: "17"
           cache: gradle
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
       - name: Build debug and release
         run: ./gradlew assembleDebug assembleRelease --no-daemon
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,133 @@
+name: Android Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: Google Play track
+        required: true
+        default: internal
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+      status:
+        description: Release status in Play Console
+        required: true
+        default: completed
+        type: choice
+        options:
+          - completed
+          - draft
+          - inProgress
+          - halted
+      version_name:
+        description: Android versionName (defaults to 0.1.<run_number>)
+        required: false
+        type: string
+  push:
+    tags:
+      - "android/v*"
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile/android
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Validate release secrets
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          missing=()
+          for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD GOOGLE_PLAY_SERVICE_ACCOUNT_JSON; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "Missing required GitHub secrets: ${missing[*]}"
+            echo "Configure secrets using docs/android-play-publish-setup.md"
+            exit 1
+          fi
+
+      - name: Decode upload keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/upload-keystore.jks"
+          echo "ANDROID_KEYSTORE_PATH=$RUNNER_TEMP/upload-keystore.jks" >> "$GITHUB_ENV"
+
+      - name: Resolve release metadata
+        id: release_meta
+        run: |
+          if [ -n "${{ github.event.inputs.version_name }}" ]; then
+            version_name="${{ github.event.inputs.version_name }}"
+          else
+            version_name="0.1.${{ github.run_number }}"
+          fi
+          echo "version_code=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "version_name=${version_name}" >> "$GITHUB_OUTPUT"
+          echo "track=${{ github.event.inputs.track || 'internal' }}" >> "$GITHUB_OUTPUT"
+          echo "status=${{ github.event.inputs.status || 'completed' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build signed release AAB
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_VERSION_CODE: ${{ steps.release_meta.outputs.version_code }}
+          ANDROID_VERSION_NAME: ${{ steps.release_meta.outputs.version_name }}
+        run: ./gradlew :app:bundleRelease --no-daemon
+
+      - name: Generate release manifest
+        working-directory: .
+        run: python3 mobile/scripts/generate_release_manifest.py
+
+      - name: Upload to Google Play
+        uses: r0adkll/upload-google-play@v1.1.3
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.hiair
+          releaseFiles: mobile/android/app/build/outputs/bundle/release/app-release.aab
+          track: ${{ steps.release_meta.outputs.track }}
+          status: ${{ steps.release_meta.outputs.status }}
+          releaseName: HiAir ${{ steps.release_meta.outputs.version_name }} (${{ steps.release_meta.outputs.version_code }})
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hiair-android-${{ steps.release_meta.outputs.version_name }}
+          path: mobile/android/app/build/outputs/bundle/release/app-release.aab
+          retention-days: 30
+
+      - name: Upload release manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts-manifest
+          path: docs/release-artifacts-manifest.md
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 mobile/android/local.properties
 mobile/android/.gradle/
 mobile/android/app/build/
+mobile/android/*.jks
+mobile/android/*.keystore
+mobile/android/upload-keystore.jks
 mobile/ios/build/
 mobile/ios/HiAir.xcodeproj.bak/
 mobile/ios/HiAir.xcodeproj/project.xcworkspace/xcuserdata/

--- a/docs/android-play-publish-setup.md
+++ b/docs/android-play-publish-setup.md
@@ -1,0 +1,93 @@
+# HiAir Android Play Publish Setup
+
+This guide configures automated upload of signed Android App Bundles (AAB) to Google Play.
+
+## Prerequisites
+
+1. Google Play Console app entry for package `com.hiair`.
+2. Play Console access for the Product/Founder owner (external blocker EXT-002).
+3. Upload keystore generated and registered in Play Console.
+4. Google Cloud service account with Play Developer API access.
+
+## 1. Create upload keystore
+
+From repository root:
+
+```bash
+bash mobile/android/scripts/generate_upload_keystore.sh mobile/android/upload-keystore.jks hiair-upload
+```
+
+Keep the keystore file outside git. The script prints the base64 command for CI secrets.
+
+## 2. Configure Google Play service account
+
+1. In Google Play Console: Setup -> API access.
+2. Link a Google Cloud project (or create one).
+3. Create a service account and grant Play Console user with release permissions.
+4. Download the service account JSON key.
+
+Required API: Google Play Android Developer API.
+
+## 3. Add GitHub repository secrets
+
+| Secret | Description |
+|---|---|
+| `ANDROID_KEYSTORE_BASE64` | Base64-encoded upload keystore (`.jks`) |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore password |
+| `ANDROID_KEY_ALIAS` | Key alias (default: `hiair-upload`) |
+| `ANDROID_KEY_PASSWORD` | Key password |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Full JSON content of service account key |
+
+Generate base64 keystore payload:
+
+```bash
+base64 -w 0 mobile/android/upload-keystore.jks
+```
+
+## 4. Publish from GitHub Actions
+
+Workflow: `.github/workflows/android-release.yml`
+
+Manual run:
+1. GitHub -> Actions -> Android Release -> Run workflow.
+2. Choose track (`internal` recommended for first upload).
+3. Optionally set `version_name` (defaults to `0.1.<run_number>`).
+
+Tag trigger (optional):
+
+```bash
+git tag android/v0.1.0
+git push origin android/v0.1.0
+```
+
+Tag pushes publish to the `internal` track by default.
+
+## 5. Post-publish verification
+
+1. Confirm release appears in Play Console internal testing track.
+2. Add testers and verify install on a physical device.
+3. Execute `docs/qa-checklist.md`.
+4. Attach upload evidence to external blocker issue EXT-002.
+
+## Local signed release build (optional)
+
+```bash
+export ANDROID_KEYSTORE_PATH="/absolute/path/upload-keystore.jks"
+export ANDROID_KEYSTORE_PASSWORD="..."
+export ANDROID_KEY_ALIAS="hiair-upload"
+export ANDROID_KEY_PASSWORD="..."
+export ANDROID_VERSION_CODE=2
+export ANDROID_VERSION_NAME="0.1.2"
+
+cd mobile/android
+./gradlew :app:bundleRelease --no-daemon
+```
+
+Output:
+`mobile/android/app/build/outputs/bundle/release/app-release.aab`
+
+## Notes
+
+- CI uses `github.run_number` as monotonic `versionCode`.
+- Release builds without signing env vars still compile locally/CI using debug signing (not Play-ready).
+- Manual upload fallback remains documented in `docs/store-upload-last-mile.md`.

--- a/docs/store-upload-last-mile.md
+++ b/docs/store-upload-last-mile.md
@@ -25,6 +25,14 @@ Manifest output:
 
 ## Google Play Internal Test
 
+Automated upload (recommended after secrets are configured):
+
+1. Follow `docs/android-play-publish-setup.md`.
+2. Run GitHub Actions workflow `Android Release` with track `internal`.
+3. Verify release in Play Console and assign testers.
+
+Manual upload fallback:
+
 1. Open Google Play Console -> Internal testing.
 2. Create release and upload `app-release.aab`.
 3. Add testers list.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -41,6 +41,7 @@ This folder contains native client code skeletons for:
      - `./gradlew :app:assembleDebug --no-daemon`
      - `./gradlew :app:bundleRelease --no-daemon`
      - `./gradlew :app:lintDebug --no-daemon`
+   - Play publish automation: `docs/android-play-publish-setup.md`
    - open `mobile/android` in Android Studio and run `app` module
 3. Continue UI wiring:
    - connect navigation shell to real screen composables/views

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -5,6 +5,14 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
+val releaseSigningEnvVars = listOf(
+    "ANDROID_KEYSTORE_PATH",
+    "ANDROID_KEYSTORE_PASSWORD",
+    "ANDROID_KEY_ALIAS",
+    "ANDROID_KEY_PASSWORD",
+)
+val hasReleaseSigning = releaseSigningEnvVars.all { !System.getenv(it).isNullOrBlank() }
+
 android {
     namespace = "com.hiair"
     compileSdk = 34
@@ -13,8 +21,19 @@ android {
         applicationId = "com.hiair"
         minSdk = 26
         targetSdk = 34
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = System.getenv("ANDROID_VERSION_CODE")?.toIntOrNull() ?: 1
+        versionName = System.getenv("ANDROID_VERSION_NAME") ?: "0.1.0"
+    }
+
+    signingConfigs {
+        if (hasReleaseSigning) {
+            create("release") {
+                storeFile = file(System.getenv("ANDROID_KEYSTORE_PATH")!!)
+                storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {
@@ -26,6 +45,9 @@ android {
             isMinifyEnabled = false
             buildConfigField("String", "API_BASE_URL", "\"https://api.hiair.app\"")
             manifestPlaceholders["usesCleartextTraffic"] = "false"
+            if (hasReleaseSigning) {
+                signingConfig = signingConfigs.getByName("release")
+            }
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/mobile/android/scripts/generate_upload_keystore.sh
+++ b/mobile/android/scripts/generate_upload_keystore.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEYSTORE_PATH="${1:-upload-keystore.jks}"
+KEY_ALIAS="${2:-hiair-upload}"
+VALIDITY_DAYS="${3:-10000}"
+
+if [ -f "$KEYSTORE_PATH" ]; then
+  echo "Keystore already exists: $KEYSTORE_PATH"
+  exit 1
+fi
+
+echo "Generating upload keystore at: $KEYSTORE_PATH"
+echo "Alias: $KEY_ALIAS"
+echo "You will be prompted for keystore and key passwords."
+
+keytool -genkeypair \
+  -v \
+  -keystore "$KEYSTORE_PATH" \
+  -alias "$KEY_ALIAS" \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity "$VALIDITY_DAYS" \
+  -dname "CN=HiAir, OU=Mobile, O=HiAir, L=Unknown, ST=Unknown, C=US"
+
+echo
+echo "Keystore created."
+echo "Next steps:"
+echo "1. Register upload key in Google Play Console (App integrity)."
+echo "2. Encode keystore for GitHub secret ANDROID_KEYSTORE_BASE64:"
+echo "   base64 -w 0 \"$KEYSTORE_PATH\""
+echo "3. Store passwords and alias in GitHub secrets:"
+echo "   ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS, ANDROID_KEY_PASSWORD"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds engineering-side automation to publish HiAir Android builds to Google Play.

- Release signing is configured from CI secrets (`ANDROID_KEYSTORE_*`).
- New GitHub Actions workflow `Android Release` builds a signed AAB and uploads it to a selected Play track.
- Android CI now installs the Android SDK so release builds can run in CI.
- Operator setup guide documents keystore generation, service account setup, and required GitHub secrets.

## How to publish

1. Complete setup in `docs/android-play-publish-setup.md`.
2. Add GitHub secrets:
   - `ANDROID_KEYSTORE_BASE64`
   - `ANDROID_KEYSTORE_PASSWORD`
   - `ANDROID_KEY_ALIAS`
   - `ANDROID_KEY_PASSWORD`
   - `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
3. Run **Actions → Android Release** with track `internal`.

## Notes

- External blocker EXT-002 (Play Console access) still requires owner credentials and first successful upload evidence.
- Manual upload fallback remains in `docs/store-upload-last-mile.md`.
- Local/CI builds without signing env vars still compile using debug signing and are not Play-ready.

## Test plan

- [x] `./gradlew :app:bundleRelease` succeeds locally without signing env vars
- [x] `./gradlew :app:bundleRelease` succeeds with test upload keystore env vars
- [ ] Run `Android Release` workflow after secrets are configured
- [ ] Verify internal track release in Google Play Console
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b6c52dc-2196-4747-a9d9-45d2961de027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b6c52dc-2196-4747-a9d9-45d2961de027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

