### PR TITLE
fix: P0 device recovery (startup, geo, HealthKit, StoreKit)

### DIFF
--- a/docs/audit/P0_DEVICE_RECOVERY_BASELINE.md
+++ b/docs/audit/P0_DEVICE_RECOVERY_BASELINE.md
@@ -1,0 +1,47 @@
+# P0 Device Recovery — Baseline Checkpoint
+
+**Date:** 2026-07-23  
+**Branch:** `fix/p0-device-recovery` (from `main` @ `5ffb6f2`)  
+**Rollback point:** `5ffb6f2da9fae29639fec50ec07a458f7005a3b9`  
+**Production code SHA:** `02439521f3c56eb7ebe0fe6119d0be2179138293` (docs tip `5ffb6f2` is docs-only after deploy)  
+**Production health:** `https://api.hiair.io/api/health` → `deploy_git_sha=0243952…`  
+**TestFlight:** build **109**, marketing `0.1.0`, `VALID` / `READY_FOR_BETA_TESTING`  
+**Working tree at branch create:** clean of tracked changes (untracked `.tools/` / docs noise ignored)
+
+## Known device failures (owner-reported on TF 109)
+
+| # | Flow | Symptom |
+|---|------|---------|
+| 1 | Startup | App does not refresh data on launch |
+| 2 | Geolocation | Location not determined / not applied |
+| 3 | HealthKit | Connect Health hangs |
+| 4 | Premium | Plan does not activate / entitlement not unlocked |
+
+## Code audit hypotheses (pre-fix)
+
+| Flow | Top root cause | Evidence |
+|------|----------------|----------|
+| Startup | Dashboard `.task` awaits location before fetch; empty `profileId` without location; no `scenePhase` refresh; duplicate parallel bootstraps | `DashboardView.swift`, `RootTabView.swift`, `AppSession.swift` |
+| Geolocation | On `.notDetermined` bootstrap returns immediately; no auto-fetch after Allow | `AppSession.bootstrapLocationFromDevice`, `LocationService.locationManagerDidChangeAuthorization` |
+| HealthKit | Connect UI awaits 50–75 sequential HK queries with no timeout after auth | `WearableConsentView.connect`, `HealthKitService.syncHealthIntelligence` |
+| Premium | ASC empty catalog still possible; verify `finish()` gated on `is_premium`; OAuth path skips `refreshEntitlement` | `SubscriptionService`, `AppSession` NC observer |
+
+## Expected integrated flow (certification target)
+
+Fresh install → session → profile → location → Health → Dashboard → StoreKit purchase → entitlement → Premium unlock → restart → re-login → restore.
+
+## Safety rules in force
+
+- No Premium bypass, no fake location/health/StoreKit.
+- Separate commits per subsystem.
+- Device PASS requires physical iPhone evidence (simulator ≠ PASS).
+- Rollback: `git checkout 5ffb6f2` / reset branch to this SHA.
+
+## Commit plan
+
+1. `fix: restore deterministic startup refresh`
+2. `fix: restore end-to-end geolocation bootstrap`
+3. `fix: prevent healthkit connection hangs`
+4. `fix: restore storekit premium activation`
+5. `test: certify device recovery flows`
+6. `docs: document p0 device recovery evidence`

--- a/docs/audit/P0_DEVICE_RECOVERY_FINAL_REPORT.md
+++ b/docs/audit/P0_DEVICE_RECOVERY_FINAL_REPORT.md
@@ -1,0 +1,179 @@
+# P0 Device Recovery — Final Report
+
+**Date:** 2026-07-23  
+**Branch:** `fix/p0-device-recovery`  
+**Base:** `main` @ `5ffb6f2` (production API code `0243952`)  
+**Rollback:** `5ffb6f2`  
+**Verdict:** **CODE FIXED — WAITING FOR PHYSICAL RETEST**
+
+Physical iPhone certification of TF build >109 is **required** before any stronger verdict. Simulator / unit tests ≠ device E2E PASS.
+
+---
+
+## 1. Executive Summary
+
+Stage 0 engineering was already green. Device product flows failed on TF 109 (startup refresh, geolocation, HealthKit hang, Premium unlock). Code audit found concrete root causes; minimal fixes landed on `fix/p0-device-recovery` with unit tests green. **No physical-device PASS claimed.**
+
+---
+
+## 2. Reproduced Failures
+
+| Flow | Build | Device result | Failure point |
+|------|-------|---------------|---------------|
+| Startup refresh | TF 109 | Owner-reported FAIL | Dashboard awaited location; empty profile without location; no foreground refresh |
+| Geolocation | TF 109 | Owner-reported FAIL | Bootstrap returned on `.notDetermined`; no post-Allow retry |
+| HealthKit connect | TF 109 | Owner-reported hang | Connect UI awaited 50–75 HK queries + sync |
+| Premium | TF 109 | Owner-reported FAIL | Possible ASC empty catalog + `finish()` gated on `is_premium` + OAuth skipped entitlement refresh |
+
+---
+
+## 3. Root Causes
+
+| Flow | Root cause | Evidence |
+|------|------------|----------|
+| Startup | Parallel bootstraps; dashboard blocked on location; no `scenePhase` refresh | `DashboardView.task`, `RootTabView.task` |
+| Geolocation | One-shot bootstrap; onboarding 800ms race; concurrent fetch overwrote continuation | `AppSession.bootstrapLocationFromDevice`, `LocationService` |
+| HealthKit | Connect awaited full collect+sync; no auth single-flight; no collect timeout | `WearableConsentView.connect`, `HealthKitService` |
+| Premium | `transaction.finish()` only when `is_premium`; restore ignored unfinished; sessionDidChange no `/me` | `SubscriptionService`, `AppSession` |
+
+---
+
+## 4. Startup (code status)
+
+| Scenario | Result |
+|----------|--------|
+| Cold start | CODE FIXED — `prepareSessionForDataFetch` single-flight |
+| Warm start | CODE FIXED — same path |
+| Foreground refresh | CODE FIXED — `scenePhase == .active` → `refreshOnForeground` |
+| Offline recovery | PARTIAL — existing API timeouts; not newly device-proven |
+| Partial readiness | CODE FIXED — dashboard paints when profile exists without waiting on location |
+
+---
+
+## 5. Geolocation (code status)
+
+| Scenario | Result |
+|----------|--------|
+| Permission | CODE FIXED — grant posts `locationAuthorizationDidBecomeAuthorized` |
+| Real location | CODE FIXED — auto bootstrap after Allow |
+| Profile sync | UNCHANGED path `applyDeviceLocation` → PATCH |
+| Dashboard refresh | Via `locationRevision` / notification |
+| Planner refresh | Same notification path |
+| Retry | Existing Retry UI retained |
+| Restart | Uses cached coords then refreshes |
+
+---
+
+## 6. HealthKit (code status)
+
+| Scenario | Result |
+|----------|--------|
+| Availability | Unchanged check |
+| Authorization | Single-flight + 60s timeout |
+| Partial permissions | Still opaque (Apple); sync background |
+| Real records | Background sync after Connect returns |
+| Backend sync | Bounded by 45s collect timeout |
+| No records | `.dataUnavailable` retained |
+| Timeout | CODE FIXED |
+| Restart | Non-blocking dashboard sync retained |
+| Revoke/reconnect | DEVICE PENDING |
+
+---
+
+## 7. Premium (code status)
+
+| Scenario | Result |
+|----------|--------|
+| Catalog | Client unchanged; ASC empty catalog remains EXTERNAL if `Product.products` returns [] |
+| Prices | DEVICE PENDING |
+| Purchase | CODE FIXED finish-after-verify |
+| Backend verify | Unchanged contract |
+| Entitlement active | `sessionDidChange` now refreshes `/me` |
+| Planner / Insights unlock | DEVICE PENDING |
+| Restart / re-login / restore | CODE FIXED restore unfinished + honest empty message |
+| Isolation | DEVICE PENDING |
+
+---
+
+## 8. Bugs Fixed (code)
+
+1. Startup blocked / stale without foreground refresh  
+2. Location never applied after Allow  
+3. Health Connect/HealthKit Connect UI hang  
+4. StoreKit verify leave unfinished txn / restore incomplete / entitlement skip on OAuth  
+
+---
+
+## 9. Commits
+
+| Commit | Scope | Tests |
+|--------|-------|-------|
+| `85d9845` | startup refresh | AppSession prepare tests |
+| `88021a0` | geolocation bootstrap | null-island test |
+| `8823fcc` | HealthKit/HC hang | existing suite |
+| `7df0d9c` | StoreKit premium | SubscriptionServiceTests |
+| `38abf7f` | unit tests | AppSessionTests +14 selected |
+
+---
+
+## 10. Validation
+
+| Check | Result |
+|------|--------|
+| Backend suite | PASS — 197 passed |
+| iOS unit tests (AppSession + Subscription) | PASS — 14 tests |
+| Android Health Connect connect | CODE FIXED (compile not re-run in this step) |
+| Final gate | NOT RUN (defer to PR CI) |
+| Physical device E2E | **NOT RUN** |
+
+---
+
+## 11. Production
+
+| Item | Result |
+|------|--------|
+| Merge SHA | PENDING PR |
+| Production SHA | Still `0243952` until merge+deploy |
+| Deploy | Not yet |
+
+---
+
+## 12. TestFlight
+
+| Item | Result |
+|------|--------|
+| Current known good engineering | Build **109** (pre-fix) |
+| Post-merge required | Build **>109** from this branch |
+| VALID / tester group | PENDING after archive |
+
+---
+
+## 13. Physical Device Evidence
+
+| Integrated scenario | Result |
+|---------------------|--------|
+| Full fresh install → Premium → restart | **NOT RUN** |
+
+---
+
+## 14. Open P0/P1
+
+| Severity | Count |
+|----------|------:|
+| P0 | 1 (physical retest incomplete) |
+| P1 | ASC catalog empty risk if products still load as 0 |
+
+---
+
+## 15. Remaining External Blockers
+
+- Physical iPhone retest on new TestFlight  
+- ASC Paid Apps / IAP visibility if catalog empty  
+- Play Console for Android device billing  
+- Prefer Custom Cloudflare API Token (ops stability)
+
+---
+
+## 16. Final Verdict
+
+**CODE FIXED — WAITING FOR PHYSICAL RETEST**

--- a/docs/next-agent-handoff.md
+++ b/docs/next-agent-handoff.md
@@ -1,51 +1,34 @@
-# HiAir Development Handoff for Next Agent
+# Next agent handoff — P0 Device Recovery
 
-Date: 2026-07-21 (Health Intelligence release certification)
+## Current state
 
-## Current verdict
+- Branch: `fix/p0-device-recovery` (PR to `main`)
+- Verdict: **CODE FIXED — WAITING FOR PHYSICAL RETEST**
+- Production API still on `0243952` until PR merge + deploy
+- TF 109 is pre-fix; need build >109 after merge
 
-**PRODUCTION DEPLOYED — WAITING FOR DEVICE HEALTH DATA**
+## What was fixed (code)
 
-Do **not** claim `HEALTH INTELLIGENCE E2E VERIFIED` until physical iPhone HealthKit + physical Android Health Connect matrices pass with real records (sync → Dashboard → Insights 7/30 → personal load → AI health_context → revoke/delete).
+1. Startup single-flight + foreground refresh + diagnostics  
+2. Location auth-grant auto-bootstrap + serialized fetches  
+3. HealthKit/HC Connect no longer blocks on full sync; timeouts  
+4. StoreKit finish-after-verify; unfinished restore; entitlement refresh on session change  
 
-## Proven this session
+## Required next steps
 
-| Item | Evidence |
-|------|----------|
-| Merge | PR #30 → `6eae02a` |
-| Production SHA | `28696b0` on `https://api.hiair.io/api/health` |
-| Deploy workflow | https://github.com/2qjckdknjf-ctrl/HiAir/actions/runs/29847279318 PASS |
-| Synthetic health smoke | `scripts/release/health_intelligence_production_smoke.py` PASS |
-| Live AI | `/api/air/current-risk` `explanationSource=llm` |
-| TestFlight | **103** VALID `dce5426e-14b0-4fb1-bbf4-0c04648afaa2`, group «Первый», `IN_BETA_TESTING` |
-| Android release | Signed v2 `app-release.apk`, API `https://api.hiair.io` |
-| Play Billing | EXTERNALLY BLOCKED (no Play Console app for `com.hiair`) |
+1. Merge PR after CI green (no P0/P1 in review)  
+2. If backend unchanged: skip API redeploy; confirm health SHA still `0243952` or newer  
+3. Archive/upload TestFlight >109; assign «Первый»  
+4. Run Phase 18 physical matrix on real iPhone  
+5. Only then upgrade verdict to `IOS DEVICE RECOVERY VERIFIED`
 
-## Blockers (honest)
+## Do not
 
-1. **Physical HealthKit E2E** — install TF **103**, run checklist (tiers, real metrics, Insights 7/30, revoke/delete). No exact values in reports.
-2. **Physical Health Connect E2E** — USB Android + HC availability; OEM unsupported metrics must show honestly.
-3. **Maestro physical automation** — still flaky over CoreDevice localNetwork; USB preferred.
-4. **StoreKit sandbox purchase** — retest on TF 103 (not claimed this pass).
-
-## Immediate next actions
-
-1. Unlock iPhone → TestFlight → **103** → Health settings → tier 1–3 → confirm backend sync + Insights (no mock).
-2. Physical Android: install signed release APK → Health Connect → same matrix.
-3. After device FAIL: minimal fix → bump build (>103) → TF → retest → full regression.
-4. Only then flip verdict to `HEALTH INTELLIGENCE E2E VERIFIED` (or platform-specific VERIFIED).
-
-## Quick commands
-
-```bash
-curl -sS https://api.hiair.io/api/health
-python3.12 scripts/release/health_intelligence_production_smoke.py --expect-sha 28696b0
-bash scripts/release/hiair_final_gate.sh
-```
+- Claim device PASS from simulator  
+- Bypass Premium gates  
+- Merge with failing CI  
 
 ## Docs
 
-- `docs/audit/HEALTH_INTELLIGENCE_100_SPRINT_REPORT.md`
-- `docs/audit/HEALTH_INTELLIGENCE_COVERAGE_AUDIT.md`
-- `docs/release/qa/REAL_DEVICE_QA_REPORT.md`
-- `docs/release/FINAL_RELEASE_PROGRAM_STATUS.md`
+- `docs/audit/P0_DEVICE_RECOVERY_BASELINE.md`  
+- `docs/audit/P0_DEVICE_RECOVERY_FINAL_REPORT.md`

--- a/docs/release/qa/REAL_DEVICE_QA_REPORT.md
+++ b/docs/release/qa/REAL_DEVICE_QA_REPORT.md
@@ -1,5 +1,15 @@
 # Real Device QA Report
 
+## P0 Device Recovery (2026-07-23)
+
+**CODE FIXED — WAITING FOR PHYSICAL RETEST**
+
+Fixes are on branch `fix/p0-device-recovery` (startup / geo / HealthKit / StoreKit). Do **not** mark Startup, Location, HealthKit, or Premium as device PASS until a TestFlight build **>109** completes the Phase 18 matrix on a physical iPhone.
+
+Evidence index: `docs/audit/P0_DEVICE_RECOVERY_FINAL_REPORT.md`
+
+---
+
 ## Stage 0 update (2026-07-23)
 
 Production API is now on `0243952` (matches `main`). Latest TestFlight is build **109** (`VALID`, `READY_FOR_BETA_TESTING`). Synthetic Health / AI / Premium API smokes PASS. Interactive HealthKit / Health Connect / StoreKit / geo matrices remain **NOT RUN** on a physical device — see `docs/audit/STAGE0_FINAL_CERTIFICATION.md`.

--- a/mobile/android/app/src/main/java/com/hiair/AppMainActivity.kt
+++ b/mobile/android/app/src/main/java/com/hiair/AppMainActivity.kt
@@ -207,6 +207,7 @@ class AppMainActivity : AppCompatActivity(), WearableHealthHost, LocationBootstr
             overlayContainer = overlayContainer,
             persistSession = ::persistSession,
             clearSession = {
+                wearableHealthController.cancelPendingOperations()
                 sessionStore.clear()
                 rootShell.settingsViewModel.clearEntitlementState()
             },

--- a/mobile/android/app/src/main/java/com/hiair/health/HealthConnectService.kt
+++ b/mobile/android/app/src/main/java/com/hiair/health/HealthConnectService.kt
@@ -44,6 +44,41 @@ enum class WearableConnectionState {
 class HealthConnectService(private val context: Context) {
     private val apiClient = ApiClient(AppConfig.apiBaseUrl)
 
+    /** True only after a successful backend consent persistence in this session. */
+    @Volatile
+    var hasDurableConsent: Boolean = false
+        private set
+
+    @Volatile
+    var lastConsentError: String? = null
+        private set
+
+    @Volatile
+    var lastConnectionState: WearableConnectionState = WearableConnectionState.NOT_CONNECTED
+        private set
+
+    fun markConsentPersisted() {
+        hasDurableConsent = true
+        lastConsentError = null
+        lastConnectionState = WearableConnectionState.CONNECTED
+    }
+
+    fun markConsentFailed(message: String) {
+        hasDurableConsent = false
+        lastConsentError = message
+        lastConnectionState = WearableConnectionState.SYNC_FAILED
+    }
+
+    fun clearConsentSession() {
+        hasDurableConsent = false
+        lastConsentError = null
+        lastConnectionState = WearableConnectionState.NOT_CONNECTED
+    }
+
+    fun markConsentRevoked() {
+        clearConsentSession()
+    }
+
     val tier1Permissions = setOf(
         HealthPermission.getReadPermission(StepsRecord::class),
         HealthPermission.getReadPermission(DistanceRecord::class),

--- a/mobile/android/app/src/main/java/com/hiair/health/HealthConnectService.kt
+++ b/mobile/android/app/src/main/java/com/hiair/health/HealthConnectService.kt
@@ -43,10 +43,11 @@ enum class WearableConnectionState {
 
 class HealthConnectService(private val context: Context) {
     private val apiClient = ApiClient(AppConfig.apiBaseUrl)
+    private val consentPrefs = context.getSharedPreferences(CONSENT_PREFS, Context.MODE_PRIVATE)
 
-    /** True only after a successful backend consent persistence in this session. */
+    /** True only after a successful backend consent persistence (session + durable prefs). */
     @Volatile
-    var hasDurableConsent: Boolean = false
+    var hasDurableConsent: Boolean = consentPrefs.getBoolean(KEY_DURABLE_CONSENT, false)
         private set
 
     @Volatile
@@ -54,29 +55,42 @@ class HealthConnectService(private val context: Context) {
         private set
 
     @Volatile
-    var lastConnectionState: WearableConnectionState = WearableConnectionState.NOT_CONNECTED
+    var lastConnectionState: WearableConnectionState =
+        if (consentPrefs.getBoolean(KEY_DURABLE_CONSENT, false)) {
+            WearableConnectionState.CONNECTED
+        } else {
+            WearableConnectionState.NOT_CONNECTED
+        }
         private set
 
     fun markConsentPersisted() {
         hasDurableConsent = true
         lastConsentError = null
         lastConnectionState = WearableConnectionState.CONNECTED
+        consentPrefs.edit().putBoolean(KEY_DURABLE_CONSENT, true).apply()
     }
 
     fun markConsentFailed(message: String) {
         hasDurableConsent = false
         lastConsentError = message
         lastConnectionState = WearableConnectionState.SYNC_FAILED
+        consentPrefs.edit().putBoolean(KEY_DURABLE_CONSENT, false).apply()
     }
 
     fun clearConsentSession() {
         hasDurableConsent = false
         lastConsentError = null
         lastConnectionState = WearableConnectionState.NOT_CONNECTED
+        consentPrefs.edit().putBoolean(KEY_DURABLE_CONSENT, false).apply()
     }
 
     fun markConsentRevoked() {
         clearConsentSession()
+    }
+
+    companion object {
+        private const val CONSENT_PREFS = "hiair_wearable_consent"
+        private const val KEY_DURABLE_CONSENT = "durable_consent"
     }
 
     val tier1Permissions = setOf(

--- a/mobile/android/app/src/main/java/com/hiair/health/WearableConnectFlow.kt
+++ b/mobile/android/app/src/main/java/com/hiair/health/WearableConnectFlow.kt
@@ -1,0 +1,48 @@
+package com.hiair.health
+
+/**
+ * Consent-before-sync gate for Health Connect connect completion.
+ * Health sync runs only after durable consent persistence succeeds.
+ */
+object WearableConnectFlow {
+    enum class Outcome {
+        CONSENT_SAVED_SYNC_STARTED,
+        CONSENT_FAILED,
+        CANCELLED,
+        SKIPPED_BLANK_USER,
+    }
+
+    data class Result(
+        val outcome: Outcome,
+        val consentError: Throwable? = null,
+    )
+
+    /**
+     * Canonical post-permission path:
+     * saveConsent → verify success → only then startSync.
+     */
+    suspend fun afterPermissionsGranted(
+        userId: String,
+        accessToken: String?,
+        isCancelled: () -> Boolean = { false },
+        saveConsent: suspend (userId: String, accessToken: String?) -> Unit,
+        startSync: suspend (userId: String, accessToken: String?) -> Unit,
+    ): Result {
+        if (userId.isBlank()) {
+            return Result(Outcome.SKIPPED_BLANK_USER)
+        }
+        if (isCancelled()) {
+            return Result(Outcome.CANCELLED)
+        }
+        try {
+            saveConsent(userId, accessToken)
+        } catch (error: Exception) {
+            return Result(Outcome.CONSENT_FAILED, error)
+        }
+        if (isCancelled()) {
+            return Result(Outcome.CANCELLED)
+        }
+        startSync(userId, accessToken)
+        return Result(Outcome.CONSENT_SAVED_SYNC_STARTED)
+    }
+}

--- a/mobile/android/app/src/main/java/com/hiair/health/WearableHealthController.kt
+++ b/mobile/android/app/src/main/java/com/hiair/health/WearableHealthController.kt
@@ -73,11 +73,20 @@ class WearableHealthController(
         if (userId.isNotBlank()) {
             try {
                 healthService.saveConsent(userId, token)
-                healthService.syncHealthIntelligence(userId, token, profileId = null)
             } catch (_: Exception) {
-                // Non-blocking — dashboard still works without wearable sync.
+                // Consent failure still returns to UI; sync can retry later.
             }
         }
+        // Do not block Connect UI on Health Connect reads / backend sync.
         onComplete?.invoke()
+        if (userId.isNotBlank()) {
+            activity.lifecycleScope.launch {
+                try {
+                    healthService.syncHealthIntelligence(userId, token, profileId = null)
+                } catch (_: Exception) {
+                    // Non-blocking — dashboard still works without wearable sync.
+                }
+            }
+        }
     }
 }

--- a/mobile/android/app/src/main/java/com/hiair/health/WearableHealthController.kt
+++ b/mobile/android/app/src/main/java/com/hiair/health/WearableHealthController.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.sync.withLock
 
 /**
  * Wires Health Connect permission requests and backend consent/sync from the main activity.
- * Sync is never started unless consent persistence succeeds.
+ * Sync is never started unless consent persistence succeeds (HTTP 2xx).
  */
 class WearableHealthController(
     private val activity: ComponentActivity,
@@ -37,6 +37,7 @@ class WearableHealthController(
     private var pendingAccessToken: String? = null
     private var connectGeneration: Long = 0L
     private var connectJob: Job? = null
+    private var syncJob: Job? = null
     private val connectMutex = Mutex()
 
     fun requestConnect(userId: String, accessToken: String?, onComplete: () -> Unit) {
@@ -70,6 +71,8 @@ class WearableHealthController(
         connectGeneration += 1
         connectJob?.cancel()
         connectJob = null
+        syncJob?.cancel()
+        syncJob = null
         pendingUserId = ""
         pendingAccessToken = null
         pendingCallback = null
@@ -78,7 +81,12 @@ class WearableHealthController(
 
     fun syncIfPermitted(userId: String, accessToken: String?, profileId: String? = null) {
         if (userId.isBlank() || !healthService.isHealthConnectAvailable()) return
-        activity.lifecycleScope.launch {
+        // Fail closed: OS permissions alone are not enough without durable consent.
+        if (!healthService.hasDurableConsent) return
+        val generation = connectGeneration
+        syncJob?.cancel()
+        syncJob = activity.lifecycleScope.launch {
+            if (generation != connectGeneration) return@launch
             val granted = healthService.grantedPermissions()
             if (granted.any { it in healthService.tier1Permissions }) {
                 healthService.syncHealthIntelligence(userId, accessToken, profileId)
@@ -100,11 +108,15 @@ class WearableHealthController(
                         healthService.saveConsent(uid, access)
                     },
                     startSync = { uid, access ->
-                        activity.lifecycleScope.launch {
-                            try {
-                                healthService.syncHealthIntelligence(uid, access, profileId = null)
-                            } catch (_: Exception) {
-                                // Non-blocking — dashboard still works without wearable sync.
+                        if (generation == connectGeneration) {
+                            syncJob?.cancel()
+                            syncJob = activity.lifecycleScope.launch syncLaunch@{
+                                if (generation != connectGeneration) return@syncLaunch
+                                try {
+                                    healthService.syncHealthIntelligence(uid, access, profileId = null)
+                                } catch (_: Exception) {
+                                    // Non-blocking — dashboard still works without wearable sync.
+                                }
                             }
                         }
                     },

--- a/mobile/android/app/src/main/java/com/hiair/health/WearableHealthController.kt
+++ b/mobile/android/app/src/main/java/com/hiair/health/WearableHealthController.kt
@@ -2,13 +2,16 @@ package com.hiair.health
 
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
-import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 /**
  * Wires Health Connect permission requests and backend consent/sync from the main activity.
+ * Sync is never started unless consent persistence succeeds.
  */
 class WearableHealthController(
     private val activity: ComponentActivity,
@@ -24,11 +27,17 @@ class WearableHealthController(
                     completeConnect(callback)
                 }
             } else {
+                healthService.markConsentFailed("permission_denied")
                 callback?.invoke()
             }
         }
 
     private var pendingCallback: (() -> Unit)? = null
+    private var pendingUserId: String = ""
+    private var pendingAccessToken: String? = null
+    private var connectGeneration: Long = 0L
+    private var connectJob: Job? = null
+    private val connectMutex = Mutex()
 
     fun requestConnect(userId: String, accessToken: String?, onComplete: () -> Unit) {
         if (userId.isBlank()) {
@@ -54,6 +63,19 @@ class WearableHealthController(
         }
     }
 
+    /**
+     * Call on logout / account switch so pending consent/sync cannot leak across users.
+     */
+    fun cancelPendingOperations() {
+        connectGeneration += 1
+        connectJob?.cancel()
+        connectJob = null
+        pendingUserId = ""
+        pendingAccessToken = null
+        pendingCallback = null
+        healthService.clearConsentSession()
+    }
+
     fun syncIfPermitted(userId: String, accessToken: String?, profileId: String? = null) {
         if (userId.isBlank() || !healthService.isHealthConnectAvailable()) return
         activity.lifecycleScope.launch {
@@ -64,29 +86,47 @@ class WearableHealthController(
         }
     }
 
-    private var pendingUserId: String = ""
-    private var pendingAccessToken: String? = null
-
     private suspend fun completeConnect(onComplete: (() -> Unit)?) {
-        val userId = pendingUserId
-        val token = pendingAccessToken
-        if (userId.isNotBlank()) {
-            try {
-                healthService.saveConsent(userId, token)
-            } catch (_: Exception) {
-                // Consent failure still returns to UI; sync can retry later.
-            }
-        }
-        // Do not block Connect UI on Health Connect reads / backend sync.
-        onComplete?.invoke()
-        if (userId.isNotBlank()) {
-            activity.lifecycleScope.launch {
-                try {
-                    healthService.syncHealthIntelligence(userId, token, profileId = null)
-                } catch (_: Exception) {
-                    // Non-blocking — dashboard still works without wearable sync.
+        connectMutex.withLock {
+            val generation = connectGeneration
+            val userId = pendingUserId
+            val token = pendingAccessToken
+            val job = activity.lifecycleScope.launch {
+                val result = WearableConnectFlow.afterPermissionsGranted(
+                    userId = userId,
+                    accessToken = token,
+                    isCancelled = { generation != connectGeneration },
+                    saveConsent = { uid, access ->
+                        healthService.saveConsent(uid, access)
+                    },
+                    startSync = { uid, access ->
+                        activity.lifecycleScope.launch {
+                            try {
+                                healthService.syncHealthIntelligence(uid, access, profileId = null)
+                            } catch (_: Exception) {
+                                // Non-blocking — dashboard still works without wearable sync.
+                            }
+                        }
+                    },
+                )
+                when (result.outcome) {
+                    WearableConnectFlow.Outcome.CONSENT_SAVED_SYNC_STARTED -> {
+                        healthService.markConsentPersisted()
+                    }
+                    WearableConnectFlow.Outcome.CONSENT_FAILED -> {
+                        healthService.markConsentFailed(result.consentError?.message ?: "consent_failed")
+                    }
+                    WearableConnectFlow.Outcome.CANCELLED,
+                    WearableConnectFlow.Outcome.SKIPPED_BLANK_USER -> {
+                        // No sync; leave UI recoverable.
+                    }
+                }
+                if (generation == connectGeneration) {
+                    onComplete?.invoke()
                 }
             }
+            connectJob = job
+            job.join()
         }
     }
 }

--- a/mobile/android/app/src/main/java/com/hiair/network/ApiClient.kt
+++ b/mobile/android/app/src/main/java/com/hiair/network/ApiClient.kt
@@ -472,7 +472,7 @@ class ApiClient(private val baseUrl: String) {
 
     fun saveWearableConsent(userId: String, accessToken: String?, body: String): String {
         val endpoint = "$baseUrl/api/v1/wearables/consent"
-        return request("POST", endpoint, body, authHeaders(userId, accessToken))
+        return requestStrict("POST", endpoint, body, authHeaders(userId, accessToken))
     }
 
     fun revokeWearableConsent(userId: String, accessToken: String?): String {

--- a/mobile/android/app/src/test/java/com/hiair/health/WearableConnectFlowTest.kt
+++ b/mobile/android/app/src/test/java/com/hiair/health/WearableConnectFlowTest.kt
@@ -159,14 +159,36 @@ class WearableConnectFlowTest {
     }
 
     @Test
-    fun consentRevokeBlocksFutureSyncGate() {
-        // Session flag semantics used by WearableHealthController.syncIfPermitted
+    fun consentHttpNon2xx_treatedAsFailure_noSync() = runBlocking {
+        val syncCalls = AtomicInteger(0)
+        val result = WearableConnectFlow.afterPermissionsGranted(
+            userId = "user-1",
+            accessToken = "token",
+            saveConsent = { _, _ -> throw ApiHttpException(503, "HTTP 503") },
+            startSync = { _, _ -> syncCalls.incrementAndGet() },
+        )
+        assertEquals(WearableConnectFlow.Outcome.CONSENT_FAILED, result.outcome)
+        assertEquals(0, syncCalls.get())
+    }
+
+    @Test
+    fun syncGateRequiresDurableConsentFlag() {
         val flags = ConsentSessionFlags()
-        flags.markPersisted()
-        assertTrue(flags.hasDurableConsent)
-        flags.revoke()
         assertFalse(flags.hasDurableConsent)
-        assertNull(flags.lastConsentError)
+        // Mirrors WearableHealthController.syncIfPermitted early return.
+        var syncAllowed = false
+        if (flags.hasDurableConsent) {
+            syncAllowed = true
+        }
+        assertFalse(syncAllowed)
+        flags.markPersisted()
+        if (flags.hasDurableConsent) {
+            syncAllowed = true
+        }
+        assertTrue(syncAllowed)
+        flags.revoke()
+        syncAllowed = flags.hasDurableConsent
+        assertFalse(syncAllowed)
     }
 
     @Test

--- a/mobile/android/app/src/test/java/com/hiair/health/WearableConnectFlowTest.kt
+++ b/mobile/android/app/src/test/java/com/hiair/health/WearableConnectFlowTest.kt
@@ -1,0 +1,228 @@
+package com.hiair.health
+
+import com.hiair.network.ApiHttpException
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WearableConnectFlowTest {
+
+    @Test
+    fun consentSuccess_syncCalledOnce() = runBlocking {
+        val syncCalls = AtomicInteger(0)
+        val result = WearableConnectFlow.afterPermissionsGranted(
+            userId = "user-1",
+            accessToken = "token",
+            saveConsent = { _, _ -> },
+            startSync = { _, _ -> syncCalls.incrementAndGet() },
+        )
+        assertEquals(WearableConnectFlow.Outcome.CONSENT_SAVED_SYNC_STARTED, result.outcome)
+        assertEquals(1, syncCalls.get())
+    }
+
+    @Test
+    fun consentFailure_syncNeverCalled() = runBlocking {
+        val syncCalls = AtomicInteger(0)
+        val result = WearableConnectFlow.afterPermissionsGranted(
+            userId = "user-1",
+            accessToken = "token",
+            saveConsent = { _, _ -> throw IllegalStateException("persist failed") },
+            startSync = { _, _ -> syncCalls.incrementAndGet() },
+        )
+        assertEquals(WearableConnectFlow.Outcome.CONSENT_FAILED, result.outcome)
+        assertEquals(0, syncCalls.get())
+        assertTrue(result.consentError is IllegalStateException)
+    }
+
+    @Test
+    fun consentTimeout_syncNeverCalled() = runBlocking {
+        val syncCalls = AtomicInteger(0)
+        val result = WearableConnectFlow.afterPermissionsGranted(
+            userId = "user-1",
+            accessToken = "token",
+            saveConsent = { _, _ -> throw java.util.concurrent.TimeoutException("consent timeout") },
+            startSync = { _, _ -> syncCalls.incrementAndGet() },
+        )
+        assertEquals(WearableConnectFlow.Outcome.CONSENT_FAILED, result.outcome)
+        assertEquals(0, syncCalls.get())
+    }
+
+    @Test
+    fun retry_firstFailSecondSuccess_syncOnce() = runBlocking {
+        val syncCalls = AtomicInteger(0)
+        val attempts = AtomicInteger(0)
+        val first = WearableConnectFlow.afterPermissionsGranted(
+            userId = "user-1",
+            accessToken = "token",
+            saveConsent = { _, _ ->
+                attempts.incrementAndGet()
+                throw ApiHttpException(500, "HTTP 500")
+            },
+            startSync = { _, _ -> syncCalls.incrementAndGet() },
+        )
+        assertEquals(WearableConnectFlow.Outcome.CONSENT_FAILED, first.outcome)
+        assertEquals(0, syncCalls.get())
+
+        val second = WearableConnectFlow.afterPermissionsGranted(
+            userId = "user-1",
+            accessToken = "token",
+            saveConsent = { _, _ -> attempts.incrementAndGet() },
+            startSync = { _, _ -> syncCalls.incrementAndGet() },
+        )
+        assertEquals(WearableConnectFlow.Outcome.CONSENT_SAVED_SYNC_STARTED, second.outcome)
+        assertEquals(1, syncCalls.get())
+        assertEquals(2, attempts.get())
+    }
+
+    @Test
+    fun backendUnauthorized_noSync() = runBlocking {
+        val syncCalls = AtomicInteger(0)
+        val result = WearableConnectFlow.afterPermissionsGranted(
+            userId = "user-1",
+            accessToken = "bad",
+            saveConsent = { _, _ -> throw ApiHttpException(401, "HTTP 401") },
+            startSync = { _, _ -> syncCalls.incrementAndGet() },
+        )
+        assertEquals(WearableConnectFlow.Outcome.CONSENT_FAILED, result.outcome)
+        assertEquals(0, syncCalls.get())
+    }
+
+    @Test
+    fun logoutDuringConsent_noSync() = runBlocking {
+        val syncCalls = AtomicInteger(0)
+        var cancelled = false
+        val result = WearableConnectFlow.afterPermissionsGranted(
+            userId = "user-1",
+            accessToken = "token",
+            isCancelled = { cancelled },
+            saveConsent = { _, _ ->
+                delay(10)
+                cancelled = true
+            },
+            startSync = { _, _ -> syncCalls.incrementAndGet() },
+        )
+        assertEquals(WearableConnectFlow.Outcome.CANCELLED, result.outcome)
+        assertEquals(0, syncCalls.get())
+    }
+
+    @Test
+    fun blankUser_skipsSync() = runBlocking {
+        val syncCalls = AtomicInteger(0)
+        val result = WearableConnectFlow.afterPermissionsGranted(
+            userId = "  ",
+            accessToken = null,
+            saveConsent = { _, _ -> error("should not save") },
+            startSync = { _, _ -> syncCalls.incrementAndGet() },
+        )
+        // Blank after trim? Flow checks isBlank() — "  " is blank in Kotlin.
+        assertEquals(WearableConnectFlow.Outcome.SKIPPED_BLANK_USER, result.outcome)
+        assertEquals(0, syncCalls.get())
+    }
+
+    @Test
+    fun duplicateConnect_singleFlightViaSequentialGate() = runBlocking {
+        val syncCalls = AtomicInteger(0)
+        val consentCalls = AtomicInteger(0)
+        val a = async {
+            WearableConnectFlow.afterPermissionsGranted(
+                userId = "user-1",
+                accessToken = "token",
+                saveConsent = { _, _ ->
+                    consentCalls.incrementAndGet()
+                    delay(30)
+                },
+                startSync = { _, _ -> syncCalls.incrementAndGet() },
+            )
+        }
+        val b = async {
+            WearableConnectFlow.afterPermissionsGranted(
+                userId = "user-1",
+                accessToken = "token",
+                saveConsent = { _, _ ->
+                    consentCalls.incrementAndGet()
+                    delay(30)
+                },
+                startSync = { _, _ -> syncCalls.incrementAndGet() },
+            )
+        }
+        a.await()
+        b.await()
+        // Flow itself is not mutexed; controller mutex covers UI. Assert each success syncs once.
+        assertEquals(2, consentCalls.get())
+        assertEquals(2, syncCalls.get())
+    }
+
+    @Test
+    fun consentRevokeBlocksFutureSyncGate() {
+        // Session flag semantics used by WearableHealthController.syncIfPermitted
+        val flags = ConsentSessionFlags()
+        flags.markPersisted()
+        assertTrue(flags.hasDurableConsent)
+        flags.revoke()
+        assertFalse(flags.hasDurableConsent)
+        assertNull(flags.lastConsentError)
+    }
+
+    @Test
+    fun persistedConsentRequiredBeforeConnectedUi() {
+        val flags = ConsentSessionFlags()
+        assertFalse(flags.hasDurableConsent)
+        assertEquals(WearableConnectionState.NOT_CONNECTED, flags.lastConnectionState)
+        flags.markFailed("timeout")
+        assertFalse(flags.hasDurableConsent)
+        assertEquals(WearableConnectionState.SYNC_FAILED, flags.lastConnectionState)
+        flags.markPersisted()
+        assertTrue(flags.hasDurableConsent)
+        assertEquals(WearableConnectionState.CONNECTED, flags.lastConnectionState)
+    }
+
+    @Test
+    fun partialConsent_syncOnlyAfterConsentForAllowedPath() = runBlocking {
+        val allowedCategories = mutableListOf<String>()
+        val result = WearableConnectFlow.afterPermissionsGranted(
+            userId = "user-1",
+            accessToken = "token",
+            saveConsent = { _, _ -> allowedCategories += "tier1" },
+            startSync = { _, _ ->
+                // Sync payload path only runs after consent; categories filtered by permissions later.
+                assertTrue(allowedCategories.contains("tier1"))
+            },
+        )
+        assertEquals(WearableConnectFlow.Outcome.CONSENT_SAVED_SYNC_STARTED, result.outcome)
+        assertEquals(listOf("tier1"), allowedCategories)
+    }
+}
+
+/** Mirrors HealthConnectService consent session flags for pure unit tests. */
+private class ConsentSessionFlags {
+    var hasDurableConsent: Boolean = false
+        private set
+    var lastConsentError: String? = null
+        private set
+    var lastConnectionState: WearableConnectionState = WearableConnectionState.NOT_CONNECTED
+        private set
+
+    fun markPersisted() {
+        hasDurableConsent = true
+        lastConsentError = null
+        lastConnectionState = WearableConnectionState.CONNECTED
+    }
+
+    fun markFailed(message: String) {
+        hasDurableConsent = false
+        lastConsentError = message
+        lastConnectionState = WearableConnectionState.SYNC_FAILED
+    }
+
+    fun revoke() {
+        hasDurableConsent = false
+        lastConsentError = null
+        lastConnectionState = WearableConnectionState.NOT_CONNECTED
+    }
+}

--- a/mobile/ios/HiAir.xcodeproj/project.pbxproj
+++ b/mobile/ios/HiAir.xcodeproj/project.pbxproj
@@ -21,9 +21,11 @@
 		218A1D239B38024245EB822C /* HealthIntelligenceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DD51FD5CC5B9ECEB95787E /* HealthIntelligenceModels.swift */; };
 		21DA068E82B7BCAB678446E2 /* PurchaseSingleFlightGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246EC419CE71D319699FD8CB /* PurchaseSingleFlightGuard.swift */; };
 		2F0374CE92BBDF7A80EC07B2 /* AppSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE1D6F2C6C90D8A4CA6C8D7 /* AppSessionTests.swift */; };
+		322B36A8EF64B2A533BA618A /* HealthKitTimeoutRace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 633C39532BF5572FD090BFB8 /* HealthKitTimeoutRace.swift */; };
 		3AC3E0ADDBFFD0DC43F7E86C /* StartupDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECBE1C770399F50F75291D /* StartupDiagnostics.swift */; };
 		3E3C742D4984CEFCDFCB654F /* StoreProductFetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = A364D644D684423921A0EDAA /* StoreProductFetching.swift */; };
 		3FB8472EE51B0BBBBDC834DF /* DailyPlannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67EAE1A22084EFF9B3310D5 /* DailyPlannerView.swift */; };
+		47FDE2DE4AB462EA0052DD48 /* HealthKitTimeoutRaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDE901D8AA8E90B7F88CA47 /* HealthKitTimeoutRaceTests.swift */; };
 		495E02E3BAC0F3A167563E5C /* SymptomLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030CBAFA89BD721FF0066134 /* SymptomLogView.swift */; };
 		4D84DF0F1974CDEEF384A0F9 /* HiAirSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C19DE8CB0A73BCBFB52D37CE /* HiAirSpacing.swift */; };
 		52A613D5DA6B3312A5A5F249 /* HiAirStatusChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0D6651A44B2FD5781660545 /* HiAirStatusChip.swift */; };
@@ -50,6 +52,7 @@
 		B5875FBC5C5B3032EE02124A /* RiskAccentColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E66A00598B11116F22A217 /* RiskAccentColor.swift */; };
 		BA5EEFEA16CA6962363CB004 /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3067FB46BAFE989CA0A16E0E /* DashboardView.swift */; };
 		BF994356A47D50BB6E84B94C /* WearableConsentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097CA85FB80A297417CADC70 /* WearableConsentView.swift */; };
+		C1113FCF17266A966F5C04D3 /* HealthKitAuthorizationSingleFlightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB03AB32DC5D272A4BCF0999 /* HealthKitAuthorizationSingleFlightTests.swift */; };
 		C30809826565B303D0211894 /* HealthTodayMetricsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F76C9D3AC184612BAAF7ED /* HealthTodayMetricsView.swift */; };
 		E181DAAD698B8A895596F5C9 /* HiAirHumanDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B225391F981853BB27DC62E7 /* HiAirHumanDate.swift */; };
 		E28D30B53EBF55C4AD19399C /* HiAirShadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCAAB0F752D4878B739FE9A /* HiAirShadow.swift */; };
@@ -98,18 +101,21 @@
 		5D79B00DF93EE905C5824D90 /* HiAir.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = HiAir.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		606F94F2339205445B9E3E37 /* HiAirColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirColors.swift; sourceTree = "<group>"; };
 		6183833DB60B26DF8F99DF12 /* HiAirLaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirLaunchView.swift; sourceTree = "<group>"; };
+		633C39532BF5572FD090BFB8 /* HealthKitTimeoutRace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitTimeoutRace.swift; sourceTree = "<group>"; };
 		6B1CF7645DD4B0B92F0CA11F /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6C80D922CB3152908E2D2892 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		7E043E3C54AF656C2AE3DAF0 /* Tokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokens.swift; sourceTree = "<group>"; };
 		81AEC3B255250F766121E890 /* StoreProductIDs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductIDs.swift; sourceTree = "<group>"; };
 		85A830216F3D632CB7F632E5 /* SymptomTaxonomyDTOTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymptomTaxonomyDTOTests.swift; sourceTree = "<group>"; };
 		8833EA8341D4356991598891 /* RootTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabView.swift; sourceTree = "<group>"; };
+		8EDE901D8AA8E90B7F88CA47 /* HealthKitTimeoutRaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitTimeoutRaceTests.swift; sourceTree = "<group>"; };
 		93EEF3FD465B8193BE67529E /* HiAirTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = HiAirTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9BD707A08B6657EF85395B26 /* HiAirApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirApp.swift; sourceTree = "<group>"; };
 		9EADDAA7388600A083B23465 /* AtmosphericParticles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtmosphericParticles.swift; sourceTree = "<group>"; };
 		A0B75F7FAF52543E6F33F582 /* TimeOfDayBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOfDayBackground.swift; sourceTree = "<group>"; };
 		A364D644D684423921A0EDAA /* StoreProductFetching.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreProductFetching.swift; sourceTree = "<group>"; };
 		A995EC21CCEE6CB54421DDCF /* SubscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionService.swift; sourceTree = "<group>"; };
+		AB03AB32DC5D272A4BCF0999 /* HealthKitAuthorizationSingleFlightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitAuthorizationSingleFlightTests.swift; sourceTree = "<group>"; };
 		B225391F981853BB27DC62E7 /* HiAirHumanDate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirHumanDate.swift; sourceTree = "<group>"; };
 		BA64303D1E40994733CC1E0A /* ProductAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAnalytics.swift; sourceTree = "<group>"; };
 		BDCAAB0F752D4878B739FE9A /* HiAirShadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirShadow.swift; sourceTree = "<group>"; };
@@ -180,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				5BF8C26F2C4679F0DFB2F62E /* HealthKitService.swift */,
+				633C39532BF5572FD090BFB8 /* HealthKitTimeoutRace.swift */,
 				6C80D922CB3152908E2D2892 /* LocationService.swift */,
 				BA64303D1E40994733CC1E0A /* ProductAnalytics.swift */,
 				246EC419CE71D319699FD8CB /* PurchaseSingleFlightGuard.swift */,
@@ -221,6 +228,8 @@
 			children = (
 				3CE1D6F2C6C90D8A4CA6C8D7 /* AppSessionTests.swift */,
 				D5B7431269DC0B1AC625289B /* GeoCoordinatesTests.swift */,
+				AB03AB32DC5D272A4BCF0999 /* HealthKitAuthorizationSingleFlightTests.swift */,
+				8EDE901D8AA8E90B7F88CA47 /* HealthKitTimeoutRaceTests.swift */,
 				CD19456D03A4B04C03A0348B /* HiAirHumanDateTests.swift */,
 				E51B8943BC3F02E49B7FB4D0 /* SubscriptionServiceTests.swift */,
 				85A830216F3D632CB7F632E5 /* SymptomTaxonomyDTOTests.swift */,
@@ -379,6 +388,8 @@
 			files = (
 				2F0374CE92BBDF7A80EC07B2 /* AppSessionTests.swift in Sources */,
 				022C18940F38359470483E2A /* GeoCoordinatesTests.swift in Sources */,
+				C1113FCF17266A966F5C04D3 /* HealthKitAuthorizationSingleFlightTests.swift in Sources */,
+				47FDE2DE4AB462EA0052DD48 /* HealthKitTimeoutRaceTests.swift in Sources */,
 				0B19571439FFB543F25751C6 /* HiAirHumanDateTests.swift in Sources */,
 				1E1AE86A24B33D667114E29C /* SubscriptionServiceTests.swift in Sources */,
 				8ED6F86166DE120D96F89B01 /* SymptomTaxonomyDTOTests.swift in Sources */,
@@ -397,6 +408,7 @@
 				BA5EEFEA16CA6962363CB004 /* DashboardView.swift in Sources */,
 				218A1D239B38024245EB822C /* HealthIntelligenceModels.swift in Sources */,
 				7642D4EC715458CE46C68EFB /* HealthKitService.swift in Sources */,
+				322B36A8EF64B2A533BA618A /* HealthKitTimeoutRace.swift in Sources */,
 				C30809826565B303D0211894 /* HealthTodayMetricsView.swift in Sources */,
 				079F1318A8584B1939E4E3FE /* HiAirApp.swift in Sources */,
 				F8E4E8CD814CCB27DA50948D /* HiAirColors.swift in Sources */,

--- a/mobile/ios/HiAir.xcodeproj/project.pbxproj
+++ b/mobile/ios/HiAir.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		218A1D239B38024245EB822C /* HealthIntelligenceModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18DD51FD5CC5B9ECEB95787E /* HealthIntelligenceModels.swift */; };
 		21DA068E82B7BCAB678446E2 /* PurchaseSingleFlightGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246EC419CE71D319699FD8CB /* PurchaseSingleFlightGuard.swift */; };
 		2F0374CE92BBDF7A80EC07B2 /* AppSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE1D6F2C6C90D8A4CA6C8D7 /* AppSessionTests.swift */; };
+		3AC3E0ADDBFFD0DC43F7E86C /* StartupDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02ECBE1C770399F50F75291D /* StartupDiagnostics.swift */; };
 		3E3C742D4984CEFCDFCB654F /* StoreProductFetching.swift in Sources */ = {isa = PBXBuildFile; fileRef = A364D644D684423921A0EDAA /* StoreProductFetching.swift */; };
 		3FB8472EE51B0BBBBDC834DF /* DailyPlannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67EAE1A22084EFF9B3310D5 /* DailyPlannerView.swift */; };
 		495E02E3BAC0F3A167563E5C /* SymptomLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 030CBAFA89BD721FF0066134 /* SymptomLogView.swift */; };
@@ -77,6 +78,7 @@
 /* Begin PBXFileReference section */
 		009C29A00FC9406DB23BBCEA /* SubscriptionDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionDiagnostics.swift; sourceTree = "<group>"; };
 		00BEEF483B33FAEC14EFDD21 /* HiAirComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirComponents.swift; sourceTree = "<group>"; };
+		02ECBE1C770399F50F75291D /* StartupDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupDiagnostics.swift; sourceTree = "<group>"; };
 		030CBAFA89BD721FF0066134 /* SymptomLogView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymptomLogView.swift; sourceTree = "<group>"; };
 		097CA85FB80A297417CADC70 /* WearableConsentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WearableConsentView.swift; sourceTree = "<group>"; };
 		0A2CAE228241EA1938B7BC3D /* hiair-ai-guide-avatar.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "hiair-ai-guide-avatar.png"; sourceTree = "<group>"; };
@@ -181,6 +183,7 @@
 				6C80D922CB3152908E2D2892 /* LocationService.swift */,
 				BA64303D1E40994733CC1E0A /* ProductAnalytics.swift */,
 				246EC419CE71D319699FD8CB /* PurchaseSingleFlightGuard.swift */,
+				02ECBE1C770399F50F75291D /* StartupDiagnostics.swift */,
 				A364D644D684423921A0EDAA /* StoreProductFetching.swift */,
 				81AEC3B255250F766121E890 /* StoreProductIDs.swift */,
 				009C29A00FC9406DB23BBCEA /* SubscriptionDiagnostics.swift */,
@@ -423,6 +426,7 @@
 				15B3428B7D5EA741B31BF704 /* RiskModels.swift in Sources */,
 				543BC79133D25680DCFBB795 /* RootTabView.swift in Sources */,
 				5740C62DFDE5A26DFA327001 /* SettingsView.swift in Sources */,
+				3AC3E0ADDBFFD0DC43F7E86C /* StartupDiagnostics.swift in Sources */,
 				3E3C742D4984CEFCDFCB654F /* StoreProductFetching.swift in Sources */,
 				1A92F62E0EC617E5AEF0DD14 /* StoreProductIDs.swift in Sources */,
 				1C93CBBDDA86CE4492DDC214 /* SubscriptionDiagnostics.swift in Sources */,

--- a/mobile/ios/HiAir/AppSession.swift
+++ b/mobile/ios/HiAir/AppSession.swift
@@ -54,6 +54,9 @@ final class AppSession: ObservableObject {
     private let keychain = KeychainStore(service: "com.hiair.app.session")
     private let supabaseAuth = SupabaseAuthService.shared
     private var authObserver: NSObjectProtocol?
+    private var locationAuthObserver: NSObjectProtocol?
+    private var inFlightPrepare: Task<SessionPrepareResult, Never>?
+    private var lastForegroundRefreshAt: Date?
 
     init() {
         let defaults = UserDefaults.standard
@@ -112,6 +115,7 @@ final class AppSession: ObservableObject {
                 self.accessToken = session.accessToken
                 self.refreshToken = session.refreshToken
                 self.authNotice = ""
+                await self.refreshEntitlement()
             }
         }
         NotificationCenter.default.addObserver(
@@ -135,7 +139,20 @@ final class AppSession: ObservableObject {
                 self?.applyEntitlement(entitlement)
             }
         }
+        locationAuthObserver = NotificationCenter.default.addObserver(
+            forName: .locationAuthorizationDidBecomeAuthorized,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                StartupDiagnostics.track("location_bootstrap_started", errorCode: "auth_granted")
+                _ = await self.bootstrapLocationFromDevice()
+                _ = await self.ensureProfileIdIfNeeded()
+            }
+        }
         Task { @MainActor [weak self] in
+            StartupDiagnostics.track("startup_begin")
             await self?.restoreSupabaseSession()
             await self?.refreshEntitlement()
         }
@@ -144,6 +161,9 @@ final class AppSession: ObservableObject {
     deinit {
         if let authObserver {
             NotificationCenter.default.removeObserver(authObserver)
+        }
+        if let locationAuthObserver {
+            NotificationCenter.default.removeObserver(locationAuthObserver)
         }
     }
 
@@ -207,12 +227,99 @@ final class AppSession: ObservableObject {
             isPremium = false
             return
         }
+        StartupDiagnostics.track("entitlement_refresh_started", profilePresent: !profileId.isEmpty)
+        let started = Date()
         do {
             let status = try await apiClient.fetchMySubscription(userId: userId, accessToken: accessToken)
             applyEntitlement(status.entitlement)
+            StartupDiagnostics.track(
+                "entitlement_refresh_succeeded",
+                success: true,
+                durationMs: Int(Date().timeIntervalSince(started) * 1000),
+                profilePresent: !profileId.isEmpty
+            )
         } catch {
+            StartupDiagnostics.track(
+                "entitlement_refresh_failed",
+                success: false,
+                durationMs: Int(Date().timeIntervalSince(started) * 1000),
+                errorCode: "transient"
+            )
             // Keep current premium flag on transient errors (e.g. right after StoreKit verify).
         }
+    }
+
+    /// Single-flight startup prepare: location bootstrap + profile hydrate without blocking UI forever.
+    struct SessionPrepareResult: Equatable {
+        var profileReady: Bool
+        var locationReady: Bool
+        var locationAttempted: Bool
+    }
+
+    @discardableResult
+    func prepareSessionForDataFetch(
+        locationService: LocationProviding = LocationService.shared
+    ) async -> SessionPrepareResult {
+        if let inFlightPrepare {
+            return await inFlightPrepare.value
+        }
+        let task = Task { @MainActor [weak self] () -> SessionPrepareResult in
+            guard let self else {
+                return SessionPrepareResult(profileReady: false, locationReady: false, locationAttempted: false)
+            }
+            let started = Date()
+            StartupDiagnostics.track("session_restore_started", profilePresent: !self.profileId.isEmpty)
+            var locationAttempted = false
+            if !self.hasValidLocation {
+                locationAttempted = true
+                StartupDiagnostics.track("location_bootstrap_started")
+                let ok = await self.bootstrapLocationFromDevice(locationService: locationService)
+                StartupDiagnostics.track(
+                    "location_bootstrap_succeeded",
+                    success: ok,
+                    durationMs: Int(Date().timeIntervalSince(started) * 1000)
+                )
+            }
+            StartupDiagnostics.track("profile_load_started", profilePresent: !self.profileId.isEmpty)
+            let profileOk = await self.ensureProfileIdIfNeeded()
+            StartupDiagnostics.track(
+                "profile_load_succeeded",
+                success: profileOk,
+                durationMs: Int(Date().timeIntervalSince(started) * 1000),
+                profilePresent: profileOk
+            )
+            let result = SessionPrepareResult(
+                profileReady: profileOk,
+                locationReady: self.hasValidLocation,
+                locationAttempted: locationAttempted
+            )
+            StartupDiagnostics.track(
+                result.profileReady ? "startup_ready" : "startup_partial_ready",
+                success: result.profileReady,
+                durationMs: Int(Date().timeIntervalSince(started) * 1000),
+                profilePresent: result.profileReady
+            )
+            return result
+        }
+        inFlightPrepare = task
+        let result = await task.value
+        if inFlightPrepare == task {
+            inFlightPrepare = nil
+        }
+        return result
+    }
+
+    /// Debounced foreground refresh — does not block forever on location.
+    func refreshOnForeground(locationService: LocationProviding = LocationService.shared) async {
+        let now = Date()
+        if let lastForegroundRefreshAt, now.timeIntervalSince(lastForegroundRefreshAt) < 8 {
+            return
+        }
+        lastForegroundRefreshAt = now
+        StartupDiagnostics.track("dashboard_refresh_started", errorCode: "foreground")
+        _ = await prepareSessionForDataFetch(locationService: locationService)
+        await refreshEntitlement()
+        NotificationCenter.default.post(name: .profileLocationDidUpdate, object: nil)
     }
 
     func expireSessionAfterAuthFailure() {
@@ -940,6 +1047,7 @@ enum HiAirL10n {
             "paywall.verification_failed": "Не удалось проверить покупку. Premium не активирован.",
             "paywall.purchase_in_progress": "Покупка уже выполняется. Подождите завершения.",
             "paywall.restore_success": "Покупки восстановлены.",
+            "paywall.restore_nothing": "Активных Premium-покупок для этого Apple ID не найдено.",
             "paywall.generic_error": "Не удалось завершить покупку. Попробуйте ещё раз.",
             "paywall.server_error": "Сервер временно недоступен. Попробуйте чуть позже.",
             "paywall.network_error": "Нет соединения. Проверьте интернет и повторите.",
@@ -1626,6 +1734,7 @@ enum HiAirL10n {
             "paywall.verification_failed": "Purchase verification failed. Premium was not activated.",
             "paywall.purchase_in_progress": "A purchase is already in progress. Please wait.",
             "paywall.restore_success": "Purchases restored.",
+            "paywall.restore_nothing": "No active Premium purchases found for this Apple ID.",
             "paywall.generic_error": "Couldn’t complete the purchase. Please try again.",
             "paywall.server_error": "Server temporarily unavailable. Try again shortly.",
             "paywall.network_error": "No connection. Check the internet and try again.",

--- a/mobile/ios/HiAir/Screens/DashboardView.swift
+++ b/mobile/ios/HiAir/Screens/DashboardView.swift
@@ -306,11 +306,25 @@ struct DashboardView: View {
         }
         .task {
             ProductAnalytics.track("dashboard_opened")
-            if !session.hasValidLocation {
-                _ = await session.bootstrapLocationFromDevice(locationService: locationService)
+            StartupDiagnostics.track(
+                "dashboard_refresh_started",
+                profilePresent: !session.profileId.isEmpty
+            )
+            // Never block first paint on location when profile already exists.
+            let hadProfile = !session.profileId.isEmpty
+            if hadProfile {
+                await reloadDashboard()
             }
-            await reloadDashboard()
+            let prepared = await session.prepareSessionForDataFetch(locationService: locationService)
+            if !hadProfile || prepared.locationAttempted || prepared.profileReady != hadProfile {
+                await reloadDashboard()
+            }
             session.markChecklistItem("risk", done: true)
+            StartupDiagnostics.track(
+                "dashboard_refresh_succeeded",
+                success: !viewModel.loadFailed,
+                profilePresent: !session.profileId.isEmpty
+            )
         }
         .onChange(of: session.locationRevision) { _ in
             Task { await reloadDashboard() }

--- a/mobile/ios/HiAir/Screens/OnboardingView.swift
+++ b/mobile/ios/HiAir/Screens/OnboardingView.swift
@@ -250,7 +250,12 @@ struct OnboardingView: View {
         healthService.setEnabledTiers(Set([1, 2, 3]))
         guard await healthService.requestAuthorization(tiers: Set([1, 2, 3])) else { return }
         guard !session.userId.isEmpty, !session.accessToken.isEmpty else { return }
-        try? await healthService.saveConsent(userId: session.userId, accessToken: session.accessToken)
+        do {
+            try await healthService.saveConsent(userId: session.userId, accessToken: session.accessToken)
+        } catch {
+            // Consent persistence failed — do not sync health payloads.
+            return
+        }
         let userId = session.userId
         let accessToken = session.accessToken
         let profileId = session.profileId.isEmpty ? nil : session.profileId

--- a/mobile/ios/HiAir/Screens/OnboardingView.swift
+++ b/mobile/ios/HiAir/Screens/OnboardingView.swift
@@ -103,8 +103,9 @@ struct OnboardingView: View {
         if step == 4 {
             locationService.requestWhenInUseAuthorization()
             _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])
-            try? await Task.sleep(nanoseconds: 800_000_000)
-            _ = await session.bootstrapLocationFromDevice(locationService: locationService)
+            // Permission grant is handled asynchronously via
+            // `locationAuthorizationDidBecomeAuthorized` → AppSession bootstrap.
+            // Advance onboarding without racing an 800ms sleep against the system sheet.
             step += 1
             return
         }
@@ -250,11 +251,16 @@ struct OnboardingView: View {
         guard await healthService.requestAuthorization(tiers: Set([1, 2, 3])) else { return }
         guard !session.userId.isEmpty, !session.accessToken.isEmpty else { return }
         try? await healthService.saveConsent(userId: session.userId, accessToken: session.accessToken)
-        await healthService.syncHealthIntelligence(
-            userId: session.userId,
-            accessToken: session.accessToken,
-            profileId: session.profileId.isEmpty ? nil : session.profileId
-        )
+        let userId = session.userId
+        let accessToken = session.accessToken
+        let profileId = session.profileId.isEmpty ? nil : session.profileId
+        Task {
+            await healthService.syncHealthIntelligence(
+                userId: userId,
+                accessToken: accessToken,
+                profileId: profileId
+            )
+        }
     }
 
     private var onboardingDone: some View {

--- a/mobile/ios/HiAir/Screens/PaywallView.swift
+++ b/mobile/ios/HiAir/Screens/PaywallView.swift
@@ -326,9 +326,11 @@ struct PaywallView: View {
                 accessToken: session.accessToken
             )
             session.applyEntitlement(status.entitlement)
-            statusMessage = session.l("paywall.restore_success")
             if status.entitlement?.isPremium == true || session.isPremium {
+                statusMessage = session.l("paywall.restore_success")
                 dismiss()
+            } else {
+                statusMessage = session.l("paywall.restore_nothing")
             }
         } catch SubscriptionServiceError.purchaseInProgress {
             statusMessage = session.l("paywall.purchase_in_progress")

--- a/mobile/ios/HiAir/Screens/RootTabView.swift
+++ b/mobile/ios/HiAir/Screens/RootTabView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct RootTabView: View {
     @EnvironmentObject var session: AppSession
     @EnvironmentObject var subscriptionService: SubscriptionService
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         Group {
@@ -44,10 +45,14 @@ struct RootTabView: View {
                 .toolbarBackground(HiAirLiquidGlass.material(for: .regular), for: .tabBar)
                 .toolbarBackground(.visible, for: .tabBar)
                 .task(id: session.userId) {
-                    if !session.hasValidLocation {
-                        _ = await session.bootstrapLocationFromDevice()
+                    _ = await session.prepareSessionForDataFetch()
+                }
+                .onChange(of: scenePhase) { phase in
+                    guard phase == .active else { return }
+                    guard !session.userId.isEmpty, !session.accessToken.isEmpty else { return }
+                    Task {
+                        await session.refreshOnForeground()
                     }
-                    _ = await session.ensureProfileIdIfNeeded()
                 }
             } else {
                 OnboardingView()

--- a/mobile/ios/HiAir/Screens/WearableConsentView.swift
+++ b/mobile/ios/HiAir/Screens/WearableConsentView.swift
@@ -66,12 +66,15 @@ struct WearableConsentView: View {
     private func connect() async {
         working = true
         defer { working = false }
+        ProductAnalytics.track("health_connect_started")
         guard healthService.isHealthDataAvailable() else {
             healthService.reportAuthorizationIssue("wearable.health.error.unavailable_device")
             healthService.reportConnectionState(.unavailable)
             showHealthPathHint = true
+            ProductAnalytics.track("health_availability_checked", properties: ["available": "false"])
             return
         }
+        ProductAnalytics.track("health_availability_checked", properties: ["available": "true"])
         if let issue = healthService.configurationIssueMessage() {
             healthService.reportAuthorizationIssue(issue)
             healthService.reportConnectionState(.unavailable)
@@ -83,17 +86,26 @@ struct WearableConsentView: View {
         if granted {
             do {
                 try await healthService.saveConsent(userId: session.userId, accessToken: session.accessToken)
-                await healthService.syncHealthIntelligence(
-                    userId: session.userId,
-                    accessToken: session.accessToken,
-                    profileId: session.profileId.isEmpty ? nil : session.profileId
-                )
-                await healthService.syncWearableHourlySummary(userId: session.userId, accessToken: session.accessToken)
             } catch {
                 healthService.reportConnectionState(.syncFailed)
+                showHealthPathHint = true
+                return
             }
+            // Leave the sheet immediately after authorization + consent.
+            // Heavy HK reads and backend sync must not block Connect UI.
+            let userId = session.userId
+            let accessToken = session.accessToken
+            let profileId = session.profileId.isEmpty ? nil : session.profileId
             onComplete?()
             if !fromOnboarding { dismiss() }
+            Task {
+                await healthService.syncHealthIntelligence(
+                    userId: userId,
+                    accessToken: accessToken,
+                    profileId: profileId
+                )
+                await healthService.syncWearableHourlySummary(userId: userId, accessToken: accessToken)
+            }
             return
         }
         showHealthPathHint = true

--- a/mobile/ios/HiAir/Services/HealthKitService.swift
+++ b/mobile/ios/HiAir/Services/HealthKitService.swift
@@ -71,6 +71,9 @@ final class HealthKitService: ObservableObject {
     private let defaults = UserDefaults.standard
     private let tiersKey = "hiair.health.enabledTiers"
     private let anchorKeyPrefix = "hiair.health.anchor."
+    private var authorizationInFlight: Task<Bool, Never>?
+    private let healthQueryTimeoutSeconds: TimeInterval = 12
+    private let healthCollectTimeoutSeconds: TimeInterval = 45
 
     init() {
         if let saved = defaults.array(forKey: tiersKey) as? [Int], !saved.isEmpty {
@@ -207,6 +210,22 @@ final class HealthKitService: ObservableObject {
     }
 
     func requestAuthorization(tiers: Set<Int>? = nil) async -> Bool {
+        if let authorizationInFlight {
+            return await authorizationInFlight.value
+        }
+        let task = Task { @MainActor [weak self] () -> Bool in
+            guard let self else { return false }
+            return await self.performAuthorizationRequest(tiers: tiers)
+        }
+        authorizationInFlight = task
+        let result = await task.value
+        if authorizationInFlight == task {
+            authorizationInFlight = nil
+        }
+        return result
+    }
+
+    private func performAuthorizationRequest(tiers: Set<Int>?) async -> Bool {
         lastAuthorizationError = nil
         if let tiers {
             setEnabledTiers(tiers)
@@ -214,22 +233,47 @@ final class HealthKitService: ObservableObject {
         if let issueKey = configurationIssueMessage() {
             lastAuthorizationError = issueKey
             connectionState = .unavailable
+            ProductAnalytics.track("health_connect_failed", properties: ["error_code": "config"])
             return false
         }
         connectionState = .permissionRequested
+        ProductAnalytics.track("health_authorization_started")
         let types = activeReadTypes
-        let requestError = await withCheckedContinuation { continuation in
-            store.requestAuthorization(toShare: [], read: types) { _, error in
-                continuation.resume(returning: error)
+        let requestError: Error? = await withTaskGroup(of: Error?.self) { group in
+            group.addTask {
+                await withCheckedContinuation { continuation in
+                    self.store.requestAuthorization(toShare: [], read: types) { _, error in
+                        continuation.resume(returning: error)
+                    }
+                }
             }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: 60_000_000_000)
+                return NSError(
+                    domain: "com.hiair.healthkit",
+                    code: 408,
+                    userInfo: [NSLocalizedDescriptionKey: "authorization_timeout"]
+                )
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first ?? nil
         }
         if let requestError {
-            lastAuthorizationError = Self.userFacingAuthorizationError(requestError)
-            connectionState = .permissionDenied
+            if (requestError as NSError).code == 408 {
+                lastAuthorizationError = "wearable.health.error.generic|timeout"
+                connectionState = .syncFailed
+                ProductAnalytics.track("health_connect_timeout", properties: ["stage": "authorization"])
+            } else {
+                lastAuthorizationError = Self.userFacingAuthorizationError(requestError)
+                connectionState = .permissionDenied
+                ProductAnalytics.track("health_connect_failed", properties: ["error_code": "authorization"])
+            }
             return false
         }
         // Completing the sheet registers the app; actual read grants stay opaque.
         connectionState = .connected
+        ProductAnalytics.track("health_authorization_completed", properties: ["success": "true"])
         return true
     }
 
@@ -469,8 +513,19 @@ final class HealthKitService: ObservableObject {
     }
 
     func syncHealthIntelligence(userId: String, accessToken: String, profileId: String?) async {
+        ProductAnalytics.track("health_sync_started")
         do {
-            let (snapshots, sleep) = await collectTodaySnapshots()
+            let collected = await withTimeout(seconds: healthCollectTimeoutSeconds) {
+                await self.collectTodaySnapshots()
+            }
+            guard let (snapshots, sleep) = collected else {
+                connectionState = .syncFailed
+                lastSyncError = "wearable.health.error.generic|timeout"
+                ProductAnalytics.track("health_connect_timeout", properties: ["stage": "collect"])
+                return
+            }
+            latestSnapshots = snapshots
+            latestSleep = sleep
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withFullDate]
             let dateString = formatter.string(from: Date())
@@ -545,6 +600,13 @@ final class HealthKitService: ObservableObject {
             connectionState = metrics.isEmpty && sleepPayload == nil ? .dataUnavailable : .connected
             lastSyncError = nil
             lastSyncAt = Date()
+            ProductAnalytics.track(
+                "health_sync_completed",
+                properties: [
+                    "success": "true",
+                    "empty": (metrics.isEmpty && sleepPayload == nil) ? "true" : "false",
+                ]
+            )
         } catch {
             let nsError = error as NSError
             if nsError.domain == "com.apple.healthkit", nsError.code == 6 {
@@ -554,6 +616,27 @@ final class HealthKitService: ObservableObject {
                 connectionState = .syncFailed
                 lastSyncError = error.localizedDescription
             }
+            ProductAnalytics.track("health_connect_failed", properties: ["error_code": "sync"])
+        }
+    }
+
+    private func withTimeout<T>(
+        seconds: TimeInterval,
+        operation: @escaping () async -> T
+    ) async -> T? {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask {
+                let value = await operation()
+                return value
+            }
+            group.addTask {
+                let ns = UInt64(max(seconds, 1) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: ns)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first ?? nil
         }
     }
 

--- a/mobile/ios/HiAir/Services/HealthKitService.swift
+++ b/mobile/ios/HiAir/Services/HealthKitService.swift
@@ -73,7 +73,10 @@ final class HealthKitService: ObservableObject {
     private let anchorKeyPrefix = "hiair.health.anchor."
     private var authorizationInFlight: Task<Bool, Never>?
     private let healthQueryTimeoutSeconds: TimeInterval = 12
-    private let healthCollectTimeoutSeconds: TimeInterval = 45
+    /// Overridable for unit tests (default 60s).
+    var authorizationTimeoutNanoseconds: UInt64 = 60_000_000_000
+    /// Overridable for unit tests (default 45s collect).
+    var healthCollectTimeoutNanoseconds: UInt64 = 45_000_000_000
 
     init() {
         if let saved = defaults.array(forKey: tiersKey) as? [Int], !saved.isEmpty {
@@ -239,42 +242,31 @@ final class HealthKitService: ObservableObject {
         connectionState = .permissionRequested
         ProductAnalytics.track("health_authorization_started")
         let types = activeReadTypes
-        let requestError: Error? = await withTaskGroup(of: Error?.self) { group in
-            group.addTask {
-                await withCheckedContinuation { continuation in
-                    self.store.requestAuthorization(toShare: [], read: types) { _, error in
-                        continuation.resume(returning: error)
-                    }
-                }
+        let outcome = await HealthKitTimeoutRace.raceCallback(
+            timeoutNanoseconds: authorizationTimeoutNanoseconds
+        ) { (finish: @escaping @Sendable (NSError?) -> Void) in
+            self.store.requestAuthorization(toShare: [], read: types) { _, error in
+                finish(error as NSError?)
             }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: 60_000_000_000)
-                return NSError(
-                    domain: "com.hiair.healthkit",
-                    code: 408,
-                    userInfo: [NSLocalizedDescriptionKey: "authorization_timeout"]
-                )
-            }
-            let first = await group.next() ?? nil
-            group.cancelAll()
-            return first ?? nil
         }
-        if let requestError {
-            if (requestError as NSError).code == 408 {
-                lastAuthorizationError = "wearable.health.error.generic|timeout"
-                connectionState = .syncFailed
-                ProductAnalytics.track("health_connect_timeout", properties: ["stage": "authorization"])
-            } else {
+        switch outcome {
+        case .timedOut:
+            lastAuthorizationError = "wearable.health.error.generic|timeout"
+            connectionState = .syncFailed
+            ProductAnalytics.track("health_connect_timeout", properties: ["stage": "authorization"])
+            return false
+        case let .value(requestError):
+            if let requestError {
                 lastAuthorizationError = Self.userFacingAuthorizationError(requestError)
                 connectionState = .permissionDenied
                 ProductAnalytics.track("health_connect_failed", properties: ["error_code": "authorization"])
+                return false
             }
-            return false
+            // Completing the sheet registers the app; actual read grants stay opaque.
+            connectionState = .connected
+            ProductAnalytics.track("health_authorization_completed", properties: ["success": "true"])
+            return true
         }
-        // Completing the sheet registers the app; actual read grants stay opaque.
-        connectionState = .connected
-        ProductAnalytics.track("health_authorization_completed", properties: ["success": "true"])
-        return true
     }
 
     static func openHealthApp() {
@@ -515,10 +507,12 @@ final class HealthKitService: ObservableObject {
     func syncHealthIntelligence(userId: String, accessToken: String, profileId: String?) async {
         ProductAnalytics.track("health_sync_started")
         do {
-            let collected = await withTimeout(seconds: healthCollectTimeoutSeconds) {
+            let collectOutcome = await HealthKitTimeoutRace.raceAsync(
+                timeoutNanoseconds: healthCollectTimeoutNanoseconds
+            ) {
                 await self.collectTodaySnapshots()
             }
-            guard let (snapshots, sleep) = collected else {
+            guard case let .value((snapshots, sleep)) = collectOutcome else {
                 connectionState = .syncFailed
                 lastSyncError = "wearable.health.error.generic|timeout"
                 ProductAnalytics.track("health_connect_timeout", properties: ["stage": "collect"])
@@ -617,26 +611,6 @@ final class HealthKitService: ObservableObject {
                 lastSyncError = error.localizedDescription
             }
             ProductAnalytics.track("health_connect_failed", properties: ["error_code": "sync"])
-        }
-    }
-
-    private func withTimeout<T>(
-        seconds: TimeInterval,
-        operation: @escaping () async -> T
-    ) async -> T? {
-        await withTaskGroup(of: T?.self) { group in
-            group.addTask {
-                let value = await operation()
-                return value
-            }
-            group.addTask {
-                let ns = UInt64(max(seconds, 1) * 1_000_000_000)
-                try? await Task.sleep(nanoseconds: ns)
-                return nil
-            }
-            let first = await group.next() ?? nil
-            group.cancelAll()
-            return first ?? nil
         }
     }
 

--- a/mobile/ios/HiAir/Services/HealthKitTimeoutRace.swift
+++ b/mobile/ios/HiAir/Services/HealthKitTimeoutRace.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// One-shot completion gate: resumes a waiter exactly once; late completions are ignored.
+final class OneShotCompletionGate<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completed = false
+    private var stored: Value?
+    private var waiter: ((Value) -> Void)?
+
+    func wait(_ handler: @escaping (Value) -> Void) {
+        lock.lock()
+        if completed {
+            let value = stored
+            lock.unlock()
+            if let value {
+                handler(value)
+            }
+            return
+        }
+        waiter = handler
+        lock.unlock()
+    }
+
+    @discardableResult
+    func complete(_ value: Value) -> Bool {
+        lock.lock()
+        guard !completed else {
+            lock.unlock()
+            return false
+        }
+        completed = true
+        stored = value
+        let handler = waiter
+        waiter = nil
+        lock.unlock()
+        handler?(value)
+        return true
+    }
+
+    var hasCompleted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return completed
+    }
+}
+
+/// Timeout race that returns without awaiting a hung callback / child task.
+enum HealthKitTimeoutRace {
+    enum Outcome<Value> {
+        case value(Value)
+        case timedOut
+    }
+
+    /// Race a callback-style operation against a timeout.
+    /// Late callbacks after timeout are ignored (no double resume).
+    /// Caller cancellation completes immediately with `.timedOut`.
+    static func raceCallback<Value: Sendable>(
+        timeoutNanoseconds: UInt64,
+        operation: @escaping (@escaping @Sendable (Value) -> Void) -> Void
+    ) async -> Outcome<Value> {
+        let gate = OneShotCompletionGate<Outcome<Value>>()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Outcome<Value>, Never>) in
+                gate.wait { outcome in
+                    continuation.resume(returning: outcome)
+                }
+
+                operation { value in
+                    _ = gate.complete(.value(value))
+                }
+
+                Task {
+                    try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                    _ = gate.complete(.timedOut)
+                }
+            }
+        } onCancel: {
+            _ = gate.complete(.timedOut)
+        }
+    }
+
+    /// Race an async operation against a timeout without awaiting a hung operation after timeout.
+    static func raceAsync<Value: Sendable>(
+        timeoutNanoseconds: UInt64,
+        operation: @escaping @Sendable () async -> Value
+    ) async -> Outcome<Value> {
+        let gate = OneShotCompletionGate<Outcome<Value>>()
+        let work = Task {
+            let value = await operation()
+            _ = gate.complete(.value(value))
+        }
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Outcome<Value>, Never>) in
+                gate.wait { outcome in
+                    continuation.resume(returning: outcome)
+                }
+
+                Task {
+                    try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                    work.cancel()
+                    _ = gate.complete(.timedOut)
+                }
+            }
+        } onCancel: {
+            work.cancel()
+            _ = gate.complete(.timedOut)
+        }
+    }
+}

--- a/mobile/ios/HiAir/Services/LocationService.swift
+++ b/mobile/ios/HiAir/Services/LocationService.swift
@@ -73,6 +73,10 @@ enum LocationServiceError: Error, Equatable {
 
 extension Notification.Name {
     static let profileLocationDidUpdate = Notification.Name("ProfileLocationDidUpdate")
+    /// Fired when authorization transitions into when-in-use / always (not on every callback).
+    static let locationAuthorizationDidBecomeAuthorized = Notification.Name(
+        "LocationAuthorizationDidBecomeAuthorized"
+    )
 }
 
 protocol LocationProviding: AnyObject {
@@ -94,6 +98,9 @@ final class LocationService: NSObject, ObservableObject, LocationProviding {
     private let manager: CLLocationManager
     private var locationContinuation: CheckedContinuation<CLLocation, Error>?
     private var timeoutTask: Task<Void, Never>?
+    private var fetchWaiters: [CheckedContinuation<CLLocation, Error>] = []
+    private var isFetchInFlight = false
+    private var previousAuthorizationStatus: CLAuthorizationStatus = .notDetermined
     private let locationTimeoutSeconds: TimeInterval = 20
 
     override init() {
@@ -102,6 +109,7 @@ final class LocationService: NSObject, ObservableObject, LocationProviding {
         manager.delegate = self
         manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         refreshAuthorizationStatus()
+        previousAuthorizationStatus = authorizationStatus
     }
 
     init(manager: CLLocationManager) {
@@ -110,6 +118,7 @@ final class LocationService: NSObject, ObservableObject, LocationProviding {
         manager.delegate = self
         manager.desiredAccuracy = kCLLocationAccuracyHundredMeters
         refreshAuthorizationStatus()
+        previousAuthorizationStatus = authorizationStatus
     }
 
     func refreshAuthorizationStatus() {
@@ -147,13 +156,17 @@ final class LocationService: NSObject, ObservableObject, LocationProviding {
 
         serviceState = .locating
         return try await withCheckedThrowingContinuation { continuation in
-            locationContinuation?.resume(throwing: LocationServiceError.timeout)
+            if isFetchInFlight {
+                fetchWaiters.append(continuation)
+                return
+            }
+            isFetchInFlight = true
             locationContinuation = continuation
             timeoutTask?.cancel()
             timeoutTask = Task { [weak self] in
                 try? await Task.sleep(nanoseconds: UInt64(self?.locationTimeoutSeconds ?? 20) * 1_000_000_000)
                 await MainActor.run {
-                    guard let self, self.locationContinuation != nil else { return }
+                    guard let self, self.locationContinuation != nil || !self.fetchWaiters.isEmpty else { return }
                     self.finishLocationFetch(with: .failure(LocationServiceError.timeout))
                 }
             }
@@ -192,8 +205,19 @@ final class LocationService: NSObject, ObservableObject, LocationProviding {
     private func finishLocationFetch(with result: Result<CLLocation, Error>) {
         timeoutTask?.cancel()
         timeoutTask = nil
-        let continuation = locationContinuation
+        let primary = locationContinuation
         locationContinuation = nil
+        let waiters = fetchWaiters
+        fetchWaiters = []
+        isFetchInFlight = false
+        let deliverSuccess: (CLLocation) -> Void = { location in
+            primary?.resume(returning: location)
+            waiters.forEach { $0.resume(returning: location) }
+        }
+        let deliverFailure: (Error) -> Void = { error in
+            primary?.resume(throwing: error)
+            waiters.forEach { $0.resume(throwing: error) }
+        }
         switch result {
         case let .success(location):
             if GeoCoordinates.isValid(location) {
@@ -205,11 +229,11 @@ final class LocationService: NSObject, ObservableObject, LocationProviding {
                         "accuracy_bucket": GeoCoordinates.accuracyBucket(for: location),
                     ]
                 )
-                continuation?.resume(returning: location)
+                deliverSuccess(location)
             } else {
                 serviceState = .error
                 ProductAnalytics.track("location_fetch_failed", properties: ["reason": "invalid_coordinate"])
-                continuation?.resume(throwing: LocationServiceError.invalidCoordinate)
+                deliverFailure(LocationServiceError.invalidCoordinate)
             }
         case let .failure(error):
             if let serviceError = error as? LocationServiceError, serviceError == .timeout {
@@ -218,7 +242,7 @@ final class LocationService: NSObject, ObservableObject, LocationProviding {
                 serviceState = .error
             }
             ProductAnalytics.track("location_fetch_failed", properties: ["reason": "error"])
-            continuation?.resume(throwing: error)
+            deliverFailure(error)
         }
     }
 }
@@ -226,11 +250,23 @@ final class LocationService: NSObject, ObservableObject, LocationProviding {
 extension LocationService: CLLocationManagerDelegate {
     nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         Task { @MainActor in
+            let previous = previousAuthorizationStatus
             refreshAuthorizationStatus()
+            previousAuthorizationStatus = authorizationStatus
             ProductAnalytics.track(
                 "location_permission_status",
                 properties: ["status": String(describing: authorizationStatus)]
             )
+            let newlyAuthorized =
+                (authorizationStatus == .authorizedWhenInUse || authorizationStatus == .authorizedAlways)
+                && previous != .authorizedWhenInUse
+                && previous != .authorizedAlways
+            if newlyAuthorized {
+                NotificationCenter.default.post(
+                    name: .locationAuthorizationDidBecomeAuthorized,
+                    object: nil
+                )
+            }
         }
     }
 

--- a/mobile/ios/HiAir/Services/StartupDiagnostics.swift
+++ b/mobile/ios/HiAir/Services/StartupDiagnostics.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Safe startup diagnostics — stages, durations, flags only (no PII / coords / health values).
+enum StartupDiagnostics {
+    static func track(
+        _ stage: String,
+        success: Bool? = nil,
+        durationMs: Int? = nil,
+        httpStatus: Int? = nil,
+        profilePresent: Bool? = nil,
+        errorCode: String? = nil
+    ) {
+        var props: [String: String] = ["stage": stage]
+        if let success {
+            props["success"] = success ? "true" : "false"
+        }
+        if let durationMs {
+            props["duration_ms"] = String(durationMs)
+        }
+        if let httpStatus {
+            props["http_status"] = String(httpStatus)
+        }
+        if let profilePresent {
+            props["profile_present"] = profilePresent ? "true" : "false"
+        }
+        if let errorCode {
+            props["error_code"] = errorCode
+        }
+        ProductAnalytics.track(stage, properties: props)
+    }
+}

--- a/mobile/ios/HiAir/Services/SubscriptionService.swift
+++ b/mobile/ios/HiAir/Services/SubscriptionService.swift
@@ -341,6 +341,27 @@ final class SubscriptionService: ObservableObject {
                 signedTransactions.append(signed)
             }
         }
+        for await result in Transaction.unfinished {
+            guard case .verified(let transaction) = result else { continue }
+            guard StoreProductIDs.all.contains(transaction.productID) else {
+                await transaction.finish()
+                continue
+            }
+            if let signed = try? signedTransactionString(from: result) {
+                signedTransactions.append(signed)
+            }
+            do {
+                _ = try await processVerifiedTransaction(
+                    result,
+                    transaction: transaction,
+                    userId: userId,
+                    accessToken: accessToken,
+                    correlationId: "restore_unfinished"
+                )
+            } catch {
+                continue
+            }
+        }
         let response = try await apiClient.restoreSubscriptions(
             userId: userId,
             platform: "ios",
@@ -427,12 +448,14 @@ final class SubscriptionService: ObservableObject {
                 correlationId: correlationId
             )
             if response.entitlement?.isPremium == true {
-                await transaction.finish()
                 NotificationCenter.default.post(
                     name: .subscriptionEntitlementDidUpdate,
                     object: response.entitlement
                 )
             }
+            // Always finish after a successful backend verify to avoid retry loops
+            // that leave Premium UI stuck on pending when entitlement flags lag.
+            await transaction.finish()
             return response
         } catch let error as APIError {
             processedTransactionIds.remove(transaction.id)

--- a/mobile/ios/HiAirTests/AppSessionTests.swift
+++ b/mobile/ios/HiAirTests/AppSessionTests.swift
@@ -57,4 +57,29 @@ final class AppSessionTests: XCTestCase {
         XCTAssertTrue(session.onboardingCompleted)
         XCTAssertFalse(session.checklistHidden)
     }
+
+    @MainActor
+    func testPrepareSessionSingleFlightReturnsConsistentResult() async {
+        let session = AppSession()
+        session.userId = "user-prepare"
+        session.accessToken = "token"
+        // Without network/location, prepare should complete (partial) and not hang.
+        async let first = session.prepareSessionForDataFetch()
+        async let second = session.prepareSessionForDataFetch()
+        let a = await first
+        let b = await second
+        XCTAssertEqual(a.profileReady, b.profileReady)
+        XCTAssertEqual(a.locationReady, b.locationReady)
+    }
+
+    @MainActor
+    func testHasValidLocationRejectsNullIsland() {
+        let session = AppSession()
+        session.latitude = 0
+        session.longitude = 0
+        XCTAssertFalse(session.hasValidLocation)
+        session.latitude = 41.39
+        session.longitude = 2.17
+        XCTAssertTrue(session.hasValidLocation)
+    }
 }

--- a/mobile/ios/HiAirTests/HealthKitAuthorizationSingleFlightTests.swift
+++ b/mobile/ios/HiAirTests/HealthKitAuthorizationSingleFlightTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import HiAir
+
+/// Mirrors HealthKitService authorization single-flight semantics for deterministic tests.
+actor AuthorizationSingleFlight {
+    private var inFlight: Task<Bool, Never>?
+
+    func request(_ operation: @escaping @Sendable () async -> Bool) async -> Bool {
+        if let inFlight {
+            return await inFlight.value
+        }
+        let task = Task { await operation() }
+        inFlight = task
+        let result = await task.value
+        if inFlight == task {
+            inFlight = nil
+        }
+        return result
+    }
+}
+
+final class HealthKitAuthorizationSingleFlightTests: XCTestCase {
+    func testConcurrentConnect_oneOperation() async {
+        let flight = AuthorizationSingleFlight()
+        let counter = Counter()
+        async let a = flight.request {
+            await counter.increment()
+            try? await Task.sleep(nanoseconds: 40_000_000)
+            return true
+        }
+        async let b = flight.request {
+            await counter.increment()
+            return true
+        }
+        let results = await (a, b)
+        XCTAssertTrue(results.0)
+        XCTAssertTrue(results.1)
+        let count = await counter.value
+        XCTAssertEqual(count, 1)
+    }
+
+    func testRetryAfterTimeout_newOperationSucceeds() async {
+        let flight = AuthorizationSingleFlight()
+        let first = await flight.request { false }
+        XCTAssertFalse(first)
+        let second = await flight.request { true }
+        XCTAssertTrue(second)
+    }
+}
+
+private actor Counter {
+    private(set) var value = 0
+    func increment() {
+        value += 1
+    }
+}

--- a/mobile/ios/HiAirTests/HealthKitTimeoutRaceTests.swift
+++ b/mobile/ios/HiAirTests/HealthKitTimeoutRaceTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import HiAir
+
+final class HealthKitTimeoutRaceTests: XCTestCase {
+    func testCallbackNeverArrives_timeoutReturns() async {
+        let outcome: HealthKitTimeoutRace.Outcome<Bool> = await HealthKitTimeoutRace.raceCallback(
+            timeoutNanoseconds: 20_000_000
+        ) { (_: @escaping @Sendable (Bool) -> Void) in
+            // Never finishes.
+        }
+        guard case .timedOut = outcome else {
+            return XCTFail("Expected timeout")
+        }
+    }
+
+    func testCallbackBeforeTimeout_returnsValue() async {
+        let outcome = await HealthKitTimeoutRace.raceCallback(timeoutNanoseconds: 500_000_000) { finish in
+            finish("ok")
+        }
+        guard case let .value(value) = outcome else {
+            return XCTFail("Expected value")
+        }
+        XCTAssertEqual(value, "ok")
+    }
+
+    func testLateCallbackAfterTimeout_ignoredSafely() async {
+        let gate = OneShotCompletionGate<String>()
+        var resumeCount = 0
+        var lastValue: String?
+        gate.wait { value in
+            resumeCount += 1
+            lastValue = value
+        }
+        XCTAssertTrue(gate.complete("timeout-winner"))
+        XCTAssertFalse(gate.complete("late-callback"))
+        XCTAssertEqual(resumeCount, 1)
+        XCTAssertEqual(lastValue, "timeout-winner")
+        XCTAssertTrue(gate.hasCompleted)
+    }
+
+    func testCallbackError_propagatesAsValue() async {
+        let error = NSError(domain: "HealthKitTest", code: 1)
+        let outcome = await HealthKitTimeoutRace.raceCallback(timeoutNanoseconds: 500_000_000) { finish in
+            finish(error)
+        }
+        guard case let .value(value) = outcome else {
+            return XCTFail("Expected error value")
+        }
+        XCTAssertEqual((value as NSError).code, 1)
+    }
+
+    func testContinuationCompletesExactlyOnce() async {
+        let gate = OneShotCompletionGate<Int>()
+        var count = 0
+        gate.wait { _ in count += 1 }
+        XCTAssertTrue(gate.complete(1))
+        XCTAssertFalse(gate.complete(2))
+        XCTAssertFalse(gate.complete(3))
+        XCTAssertEqual(count, 1)
+    }
+
+    func testAsyncOperationNeverCompletes_timeoutReturns() async {
+        let outcome = await HealthKitTimeoutRace.raceAsync(timeoutNanoseconds: 20_000_000) {
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            return "late"
+        }
+        guard case .timedOut = outcome else {
+            return XCTFail("Expected collect timeout")
+        }
+    }
+
+    func testAsyncOperationBeforeTimeout_returnsValue() async {
+        let outcome = await HealthKitTimeoutRace.raceAsync(timeoutNanoseconds: 500_000_000) {
+            "snapshots"
+        }
+        guard case let .value(value) = outcome else {
+            return XCTFail("Expected value")
+        }
+        XCTAssertEqual(value, "snapshots")
+    }
+
+    func testLateAsyncAfterTimeout_ignored() async {
+        let started = expectation(description: "late work started")
+        let outcome = await HealthKitTimeoutRace.raceAsync(timeoutNanoseconds: 30_000_000) {
+            started.fulfill()
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            return "should-be-ignored"
+        }
+        guard case .timedOut = outcome else {
+            return XCTFail("Expected timeout")
+        }
+        await fulfillment(of: [started], timeout: 1.0)
+        // Give late completion a moment; gate must stay timedOut (already returned).
+        try? await Task.sleep(nanoseconds: 250_000_000)
+    }
+
+    func testRetryAfterTimeout_newRaceSucceeds() async {
+        let first: HealthKitTimeoutRace.Outcome<Bool> = await HealthKitTimeoutRace.raceCallback(
+            timeoutNanoseconds: 20_000_000
+        ) { (_: @escaping @Sendable (Bool) -> Void) in }
+        guard case .timedOut = first else {
+            return XCTFail("Expected first timeout")
+        }
+        let second = await HealthKitTimeoutRace.raceCallback(timeoutNanoseconds: 500_000_000) { finish in
+            finish(true)
+        }
+        guard case let .value(ok) = second else {
+            return XCTFail("Expected retry success")
+        }
+        XCTAssertTrue(ok)
+    }
+
+    func testCancellationDoesNotHangCaller() async {
+        let parent = Task {
+            let _: HealthKitTimeoutRace.Outcome<Bool> = await HealthKitTimeoutRace.raceCallback(
+                timeoutNanoseconds: 2_000_000_000
+            ) { (_: @escaping @Sendable (Bool) -> Void) in }
+        }
+        // Let the race install its waiter, then cancel.
+        try? await Task.sleep(nanoseconds: 5_000_000)
+        parent.cancel()
+        let started = Date()
+        _ = await parent.value
+        XCTAssertLessThan(Date().timeIntervalSince(started), 1.0)
+    }
+}


### PR DESCRIPTION
## Summary
- Restore deterministic startup refresh (single-flight prepare, foreground refresh, safe diagnostics)
- Restore geolocation bootstrap after permission grant; serialize location fetches
- Prevent HealthKit/Health Connect Connect hangs (non-blocking sync + timeouts)
- Restore StoreKit premium activation (finish after verify, unfinished restore, entitlement refresh on session change)

## Test plan
- [x] Backend pytest 197 passed
- [x] iOS AppSessionTests + SubscriptionServiceTests (14) passed on iPhone 17 sim
- [ ] PR CI green (Backend / iOS / Android)
- [ ] Merge → TestFlight build >109 VALID → assign «Первый»
- [ ] Physical iPhone Phase 18 matrix (startup / geo / Health / Premium) — required before device PASS

## Verdict
**CODE FIXED — WAITING FOR PHYSICAL RETEST**

Do not claim device E2E PASS from this PR alone.