### PR TITLE
fix: scope durable health consent to account identity

### DIFF
--- a/mobile/android/app/src/main/java/com/hiair/AppMainActivity.kt
+++ b/mobile/android/app/src/main/java/com/hiair/AppMainActivity.kt
@@ -243,6 +243,7 @@ class AppMainActivity : AppCompatActivity(), WearableHealthHost, LocationBootstr
 
     private fun persistSession() {
         val state = rootShell.settingsViewModel.state
+        wearableHealthController.onAuthenticatedUserChanged(state.userId)
         sessionStore.save(
             StoredSession(
                 email = state.email,

--- a/mobile/android/app/src/main/java/com/hiair/health/HealthConnectService.kt
+++ b/mobile/android/app/src/main/java/com/hiair/health/HealthConnectService.kt
@@ -45,9 +45,13 @@ class HealthConnectService(private val context: Context) {
     private val apiClient = ApiClient(AppConfig.apiBaseUrl)
     private val consentPrefs = context.getSharedPreferences(CONSENT_PREFS, Context.MODE_PRIVATE)
 
-    /** True only after a successful backend consent persistence (session + durable prefs). */
+    /** True only after successful backend consent for `consentUserId`. */
     @Volatile
-    var hasDurableConsent: Boolean = consentPrefs.getBoolean(KEY_DURABLE_CONSENT, false)
+    var hasDurableConsent: Boolean = false
+        private set
+
+    @Volatile
+    var consentUserId: String = ""
         private set
 
     @Volatile
@@ -55,33 +59,58 @@ class HealthConnectService(private val context: Context) {
         private set
 
     @Volatile
-    var lastConnectionState: WearableConnectionState =
-        if (consentPrefs.getBoolean(KEY_DURABLE_CONSENT, false)) {
+    var lastConnectionState: WearableConnectionState = WearableConnectionState.NOT_CONNECTED
+        private set
+
+    init {
+        consentUserId = consentPrefs.getString(KEY_CONSENT_USER_ID, "").orEmpty()
+        hasDurableConsent = consentPrefs.getBoolean(KEY_DURABLE_CONSENT, false) && consentUserId.isNotBlank()
+        lastConnectionState = if (hasDurableConsent) {
             WearableConnectionState.CONNECTED
         } else {
             WearableConnectionState.NOT_CONNECTED
         }
-        private set
+    }
 
-    fun markConsentPersisted() {
+    fun hasDurableConsentFor(userId: String): Boolean {
+        return hasDurableConsent && userId.isNotBlank() && userId == consentUserId
+    }
+
+    fun markConsentPersisted(userId: String) {
+        if (userId.isBlank()) {
+            clearConsentSession()
+            return
+        }
         hasDurableConsent = true
+        consentUserId = userId
         lastConsentError = null
         lastConnectionState = WearableConnectionState.CONNECTED
-        consentPrefs.edit().putBoolean(KEY_DURABLE_CONSENT, true).apply()
+        consentPrefs.edit()
+            .putBoolean(KEY_DURABLE_CONSENT, true)
+            .putString(KEY_CONSENT_USER_ID, userId)
+            .apply()
     }
 
     fun markConsentFailed(message: String) {
         hasDurableConsent = false
+        consentUserId = ""
         lastConsentError = message
         lastConnectionState = WearableConnectionState.SYNC_FAILED
-        consentPrefs.edit().putBoolean(KEY_DURABLE_CONSENT, false).apply()
+        consentPrefs.edit()
+            .putBoolean(KEY_DURABLE_CONSENT, false)
+            .remove(KEY_CONSENT_USER_ID)
+            .apply()
     }
 
     fun clearConsentSession() {
         hasDurableConsent = false
+        consentUserId = ""
         lastConsentError = null
         lastConnectionState = WearableConnectionState.NOT_CONNECTED
-        consentPrefs.edit().putBoolean(KEY_DURABLE_CONSENT, false).apply()
+        consentPrefs.edit()
+            .putBoolean(KEY_DURABLE_CONSENT, false)
+            .remove(KEY_CONSENT_USER_ID)
+            .apply()
     }
 
     fun markConsentRevoked() {
@@ -91,6 +120,7 @@ class HealthConnectService(private val context: Context) {
     companion object {
         private const val CONSENT_PREFS = "hiair_wearable_consent"
         private const val KEY_DURABLE_CONSENT = "durable_consent"
+        private const val KEY_CONSENT_USER_ID = "consent_user_id"
     }
 
     val tier1Permissions = setOf(

--- a/mobile/android/app/src/main/java/com/hiair/health/WearableHealthController.kt
+++ b/mobile/android/app/src/main/java/com/hiair/health/WearableHealthController.kt
@@ -81,8 +81,8 @@ class WearableHealthController(
 
     fun syncIfPermitted(userId: String, accessToken: String?, profileId: String? = null) {
         if (userId.isBlank() || !healthService.isHealthConnectAvailable()) return
-        // Fail closed: OS permissions alone are not enough without durable consent.
-        if (!healthService.hasDurableConsent) return
+        // Fail closed: OS permissions alone are not enough; consent must match this account.
+        if (!healthService.hasDurableConsentFor(userId)) return
         val generation = connectGeneration
         syncJob?.cancel()
         syncJob = activity.lifecycleScope.launch {
@@ -90,6 +90,23 @@ class WearableHealthController(
             val granted = healthService.grantedPermissions()
             if (granted.any { it in healthService.tier1Permissions }) {
                 healthService.syncHealthIntelligence(userId, accessToken, profileId)
+            }
+        }
+    }
+
+    /**
+     * Call when auth identity changes (login / OAuth / expiry) so another account
+     * cannot inherit durable consent or in-flight sync from the previous user.
+     */
+    fun onAuthenticatedUserChanged(userId: String) {
+        if (userId.isBlank()) {
+            cancelPendingOperations()
+            return
+        }
+        if (!healthService.hasDurableConsentFor(userId)) {
+            // Different account (or no consent): drop previous account's session + jobs.
+            if (healthService.consentUserId.isNotBlank() && healthService.consentUserId != userId) {
+                cancelPendingOperations()
             }
         }
     }
@@ -123,7 +140,7 @@ class WearableHealthController(
                 )
                 when (result.outcome) {
                     WearableConnectFlow.Outcome.CONSENT_SAVED_SYNC_STARTED -> {
-                        healthService.markConsentPersisted()
+                        healthService.markConsentPersisted(userId)
                     }
                     WearableConnectFlow.Outcome.CONSENT_FAILED -> {
                         healthService.markConsentFailed(result.consentError?.message ?: "consent_failed")

--- a/mobile/android/app/src/test/java/com/hiair/health/WearableConnectFlowTest.kt
+++ b/mobile/android/app/src/test/java/com/hiair/health/WearableConnectFlowTest.kt
@@ -174,33 +174,43 @@ class WearableConnectFlowTest {
     @Test
     fun syncGateRequiresDurableConsentFlag() {
         val flags = ConsentSessionFlags()
-        assertFalse(flags.hasDurableConsent)
-        // Mirrors WearableHealthController.syncIfPermitted early return.
+        assertFalse(flags.hasDurableConsentFor("user-1"))
         var syncAllowed = false
-        if (flags.hasDurableConsent) {
+        if (flags.hasDurableConsentFor("user-1")) {
             syncAllowed = true
         }
         assertFalse(syncAllowed)
-        flags.markPersisted()
-        if (flags.hasDurableConsent) {
+        flags.markPersisted("user-1")
+        if (flags.hasDurableConsentFor("user-1")) {
             syncAllowed = true
         }
         assertTrue(syncAllowed)
         flags.revoke()
-        syncAllowed = flags.hasDurableConsent
+        syncAllowed = flags.hasDurableConsentFor("user-1")
         assertFalse(syncAllowed)
+    }
+
+    @Test
+    fun durableConsentIsScopedToUserId() {
+        val flags = ConsentSessionFlags()
+        flags.markPersisted("user-a")
+        assertTrue(flags.hasDurableConsentFor("user-a"))
+        assertFalse(flags.hasDurableConsentFor("user-b"))
+        flags.switchAccount("user-b")
+        assertFalse(flags.hasDurableConsentFor("user-a"))
+        assertFalse(flags.hasDurableConsentFor("user-b"))
     }
 
     @Test
     fun persistedConsentRequiredBeforeConnectedUi() {
         val flags = ConsentSessionFlags()
-        assertFalse(flags.hasDurableConsent)
+        assertFalse(flags.hasDurableConsentFor("user-1"))
         assertEquals(WearableConnectionState.NOT_CONNECTED, flags.lastConnectionState)
         flags.markFailed("timeout")
-        assertFalse(flags.hasDurableConsent)
+        assertFalse(flags.hasDurableConsentFor("user-1"))
         assertEquals(WearableConnectionState.SYNC_FAILED, flags.lastConnectionState)
-        flags.markPersisted()
-        assertTrue(flags.hasDurableConsent)
+        flags.markPersisted("user-1")
+        assertTrue(flags.hasDurableConsentFor("user-1"))
         assertEquals(WearableConnectionState.CONNECTED, flags.lastConnectionState)
     }
 
@@ -225,26 +235,41 @@ class WearableConnectFlowTest {
 private class ConsentSessionFlags {
     var hasDurableConsent: Boolean = false
         private set
+    var consentUserId: String = ""
+        private set
     var lastConsentError: String? = null
         private set
     var lastConnectionState: WearableConnectionState = WearableConnectionState.NOT_CONNECTED
         private set
 
-    fun markPersisted() {
+    fun hasDurableConsentFor(userId: String): Boolean {
+        return hasDurableConsent && userId.isNotBlank() && userId == consentUserId
+    }
+
+    fun markPersisted(userId: String) {
         hasDurableConsent = true
+        consentUserId = userId
         lastConsentError = null
         lastConnectionState = WearableConnectionState.CONNECTED
     }
 
     fun markFailed(message: String) {
         hasDurableConsent = false
+        consentUserId = ""
         lastConsentError = message
         lastConnectionState = WearableConnectionState.SYNC_FAILED
     }
 
     fun revoke() {
         hasDurableConsent = false
+        consentUserId = ""
         lastConsentError = null
         lastConnectionState = WearableConnectionState.NOT_CONNECTED
+    }
+
+    fun switchAccount(newUserId: String) {
+        if (consentUserId.isNotBlank() && consentUserId != newUserId) {
+            revoke()
+        }
     }
 }

--- a/mobile/ios/HiAir/AppSession.swift
+++ b/mobile/ios/HiAir/AppSession.swift
@@ -171,6 +171,7 @@ final class AppSession: ObservableObject {
         Task {
             await supabaseAuth.signOut()
         }
+        HealthKitService.shared.cancelPendingSync()
         userId = ""
         email = ""
         accessToken = ""

--- a/mobile/ios/HiAir/Screens/OnboardingView.swift
+++ b/mobile/ios/HiAir/Screens/OnboardingView.swift
@@ -259,13 +259,11 @@ struct OnboardingView: View {
         let userId = session.userId
         let accessToken = session.accessToken
         let profileId = session.profileId.isEmpty ? nil : session.profileId
-        Task {
-            await healthService.syncHealthIntelligence(
-                userId: userId,
-                accessToken: accessToken,
-                profileId: profileId
-            )
-        }
+        healthService.startBackgroundHealthSync(
+            userId: userId,
+            accessToken: accessToken,
+            profileId: profileId
+        )
     }
 
     private var onboardingDone: some View {

--- a/mobile/ios/HiAir/Screens/WearableConsentView.swift
+++ b/mobile/ios/HiAir/Screens/WearableConsentView.swift
@@ -98,14 +98,11 @@ struct WearableConsentView: View {
             let profileId = session.profileId.isEmpty ? nil : session.profileId
             onComplete?()
             if !fromOnboarding { dismiss() }
-            Task {
-                await healthService.syncHealthIntelligence(
-                    userId: userId,
-                    accessToken: accessToken,
-                    profileId: profileId
-                )
-                await healthService.syncWearableHourlySummary(userId: userId, accessToken: accessToken)
-            }
+            healthService.startBackgroundHealthSync(
+                userId: userId,
+                accessToken: accessToken,
+                profileId: profileId
+            )
             return
         }
         showHealthPathHint = true

--- a/mobile/ios/HiAir/Services/HealthKitService.swift
+++ b/mobile/ios/HiAir/Services/HealthKitService.swift
@@ -72,6 +72,8 @@ final class HealthKitService: ObservableObject {
     private let tiersKey = "hiair.health.enabledTiers"
     private let anchorKeyPrefix = "hiair.health.anchor."
     private var authorizationInFlight: Task<Bool, Never>?
+    private var syncInFlight: Task<Void, Never>?
+    private var syncGeneration: UInt64 = 0
     private let healthQueryTimeoutSeconds: TimeInterval = 12
     /// Overridable for unit tests (default 60s).
     var authorizationTimeoutNanoseconds: UInt64 = 60_000_000_000
@@ -504,7 +506,32 @@ final class HealthKitService: ObservableObject {
         )
     }
 
+    func cancelPendingSync() {
+        syncGeneration &+= 1
+        syncInFlight?.cancel()
+        syncInFlight = nil
+    }
+
+    /// Background collect+sync that is cancelled on logout / identity change.
+    func startBackgroundHealthSync(userId: String, accessToken: String, profileId: String?) {
+        let generation = syncGeneration
+        let expectedUserId = userId
+        syncInFlight?.cancel()
+        syncInFlight = Task { [weak self] in
+            guard let self else { return }
+            guard generation == self.syncGeneration, !Task.isCancelled else { return }
+            await self.syncHealthIntelligence(
+                userId: expectedUserId,
+                accessToken: accessToken,
+                profileId: profileId
+            )
+            guard generation == self.syncGeneration, !Task.isCancelled else { return }
+            await self.syncWearableHourlySummary(userId: expectedUserId, accessToken: accessToken)
+        }
+    }
+
     func syncHealthIntelligence(userId: String, accessToken: String, profileId: String?) async {
+        guard !Task.isCancelled else { return }
         ProductAnalytics.track("health_sync_started")
         do {
             let collectOutcome = await HealthKitTimeoutRace.raceAsync(
@@ -512,6 +539,7 @@ final class HealthKitService: ObservableObject {
             ) {
                 await self.collectTodaySnapshots()
             }
+            guard !Task.isCancelled else { return }
             guard case let .value((snapshots, sleep)) = collectOutcome else {
                 connectionState = .syncFailed
                 lastSyncError = "wearable.health.error.generic|timeout"


### PR DESCRIPTION
## Summary
- Bind Android durable consent to `userId` and require match before sync
- Clear consent / cancel jobs on account switch and auth expiry
- Cancel iOS background HealthKit sync on logout (closes residual MEDIUM on WearableConsentView)

Follow-up to residual review threads on merged PR #32.

## Test plan
- [x] Android `WearableConnectFlowTest` including account-scoped consent
- [x] iOS build succeeded
- [ ] CI green
- [ ] Merge + TestFlight >115 for physical retest