### PR TITLE
fix(ios): prevent duplicate profile ensure after foreground prepare

### DIFF
--- a/mobile/ios/HiAir/AppSession.swift
+++ b/mobile/ios/HiAir/AppSession.swift
@@ -701,9 +701,10 @@ final class AppSession: ObservableObject {
 
     /// Posts `.profileLocationDidUpdate` with typed ensure-ownership context.
     private func postProfileLocationDidUpdate(source: ProfileLocationUpdateContext.Source) {
+        let attributedUserId = userId.trimmingCharacters(in: .whitespacesAndNewlines)
         NotificationCenter.default.post(
             name: .profileLocationDidUpdate,
-            object: ProfileLocationUpdateContext(source: source)
+            object: ProfileLocationUpdateContext(source: source, userId: attributedUserId)
         )
     }
 

--- a/mobile/ios/HiAir/AppSession.swift
+++ b/mobile/ios/HiAir/AppSession.swift
@@ -133,6 +133,12 @@ final class AppSession: ObservableObject {
         }
     }
 
+    /// Abandon single-flight session prepare so a replacement account cannot coalesce onto it.
+    private func cancelInFlightSessionPrepare() {
+        inFlightPrepare?.cancel()
+        inFlightPrepare = nil
+    }
+
     private func isCurrentProfileEnsureContext(
         userId: String,
         accessToken: String,
@@ -391,6 +397,7 @@ final class AppSession: ObservableObject {
     }
 
     func logout() {
+        cancelInFlightSessionPrepare()
         cancelInFlightProfileEnsure(clearOutcome: true)
 
         // 1) Immutable account-correlated snapshot BEFORE any local clear.
@@ -523,8 +530,9 @@ final class AppSession: ObservableObject {
     func installAuthSession(_ auth: SupabaseAuthSession) {
         let previousUserId = userId.trimmingCharacters(in: .whitespacesAndNewlines)
         let nextUserId = auth.userId.trimmingCharacters(in: .whitespacesAndNewlines)
-        // Same-user token rotation must not cancel in-flight profile ensure.
+        // Same-user token rotation must not cancel in-flight profile ensure / prepare.
         if previousUserId != nextUserId {
+            cancelInFlightSessionPrepare()
             cancelInFlightProfileEnsure(clearOutcome: true)
         }
         durableOwnershipGeneration = durableOwnership.claim(userId: auth.userId)
@@ -633,10 +641,23 @@ final class AppSession: ObservableObject {
         if let inFlightPrepare {
             return await inFlightPrepare.value
         }
+        let ownerUserId = userId.trimmingCharacters(in: .whitespacesAndNewlines)
         let task = Task { @MainActor [weak self] () -> SessionPrepareResult in
             guard let self else {
                 return SessionPrepareResult(profileReady: false, locationReady: false, locationAttempted: false)
             }
+            let abandoned = SessionPrepareResult(
+                profileReady: false,
+                locationReady: false,
+                locationAttempted: false
+            )
+            let stillOwnedByCaller: () -> Bool = {
+                !Task.isCancelled
+                    && !ownerUserId.isEmpty
+                    && self.userId.trimmingCharacters(in: .whitespacesAndNewlines) == ownerUserId
+            }
+            guard stillOwnedByCaller() else { return abandoned }
+
             let started = Date()
             StartupDiagnostics.track("session_restore_started", profilePresent: !self.profileId.isEmpty)
             var locationAttempted = false
@@ -644,6 +665,7 @@ final class AppSession: ObservableObject {
                 locationAttempted = true
                 StartupDiagnostics.track("location_bootstrap_started")
                 let ok = await self.bootstrapLocationFromDevice(locationService: locationService)
+                guard stillOwnedByCaller() else { return abandoned }
                 StartupDiagnostics.track(
                     "location_bootstrap_succeeded",
                     success: ok,
@@ -653,8 +675,10 @@ final class AppSession: ObservableObject {
                 // Instant chip from cache happens in init; resolve if missing.
                 Task { await self.resolvePlaceNameIfNeeded() }
             }
+            guard stillOwnedByCaller() else { return abandoned }
             StartupDiagnostics.track("profile_load_started", profilePresent: !self.profileId.isEmpty)
             let profileOutcome = await self.ensureProfileIdIfNeeded()
+            guard stillOwnedByCaller() else { return abandoned }
             let profileOk = profileOutcome.isReady
             StartupDiagnostics.track(
                 "profile_load_succeeded",
@@ -690,21 +714,29 @@ final class AppSession: ObservableObject {
         if let lastForegroundRefreshAt, now.timeIntervalSince(lastForegroundRefreshAt) < 8 {
             return
         }
+        let ownerUserId = userId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !ownerUserId.isEmpty else { return }
         lastForegroundRefreshAt = now
         StartupDiagnostics.track("dashboard_refresh_started", errorCode: "foreground")
         _ = await prepareSessionForDataFetch(locationService: locationService)
+        // Auth may have switched while prepare was in flight — never attribute to the new account.
+        guard userId.trimmingCharacters(in: .whitespacesAndNewlines) == ownerUserId else { return }
         await refreshEntitlement()
+        guard userId.trimmingCharacters(in: .whitespacesAndNewlines) == ownerUserId else { return }
         // Prepare already owned profile ensure in this foreground cycle — Dashboard must
         // reload data only (typed context → skipProfileEnsure).
-        postProfileLocationDidUpdate(source: .foregroundRefresh)
+        postProfileLocationDidUpdate(source: .foregroundRefresh, attributedUserId: ownerUserId)
     }
 
     /// Posts `.profileLocationDidUpdate` with typed ensure-ownership context.
-    private func postProfileLocationDidUpdate(source: ProfileLocationUpdateContext.Source) {
-        let attributedUserId = userId.trimmingCharacters(in: .whitespacesAndNewlines)
+    private func postProfileLocationDidUpdate(
+        source: ProfileLocationUpdateContext.Source,
+        attributedUserId: String? = nil
+    ) {
+        let uid = (attributedUserId ?? userId).trimmingCharacters(in: .whitespacesAndNewlines)
         NotificationCenter.default.post(
             name: .profileLocationDidUpdate,
-            object: ProfileLocationUpdateContext(source: source, userId: attributedUserId)
+            object: ProfileLocationUpdateContext(source: source, userId: uid)
         )
     }
 
@@ -717,6 +749,7 @@ final class AppSession: ObservableObject {
         guard !(userId.isEmpty && accessToken.isEmpty) else {
             return
         }
+        cancelInFlightSessionPrepare()
         cancelInFlightProfileEnsure(clearOutcome: true)
         let ownershipGen = durableOwnershipGeneration
         let ownsDurable = durableOwnership.isCurrent(ownershipGen)

--- a/mobile/ios/HiAir/AppSession.swift
+++ b/mobile/ios/HiAir/AppSession.swift
@@ -188,6 +188,7 @@ final class AppSession: ObservableObject {
         cancelInFlightProfileEnsure(clearOutcome: false)
         placeInvalidateTask?.cancel()
         placeInvalidateTask = nil
+        lastForegroundRefreshAt = nil
         let observers = [authObserver, locationAuthObserver, oauthFailedObserver, entitlementObserver]
         authObserver = nil
         locationAuthObserver = nil
@@ -693,7 +694,22 @@ final class AppSession: ObservableObject {
         StartupDiagnostics.track("dashboard_refresh_started", errorCode: "foreground")
         _ = await prepareSessionForDataFetch(locationService: locationService)
         await refreshEntitlement()
-        NotificationCenter.default.post(name: .profileLocationDidUpdate, object: nil)
+        // Prepare already owned profile ensure in this foreground cycle — Dashboard must
+        // reload data only (typed context → skipProfileEnsure).
+        postProfileLocationDidUpdate(source: .foregroundRefresh)
+    }
+
+    /// Posts `.profileLocationDidUpdate` with typed ensure-ownership context.
+    private func postProfileLocationDidUpdate(source: ProfileLocationUpdateContext.Source) {
+        NotificationCenter.default.post(
+            name: .profileLocationDidUpdate,
+            object: ProfileLocationUpdateContext(source: source)
+        )
+    }
+
+    /// Test seam: allow a later foreground refresh cycle without waiting wall-clock debounce.
+    func resetForegroundRefreshDebounceForTests() {
+        lastForegroundRefreshAt = nil
     }
 
     func expireSessionAfterAuthFailure() {
@@ -803,7 +819,7 @@ final class AppSession: ObservableObject {
         if let name, !name.isEmpty {
             displayPlaceName = name
             RuntimePerformanceProbe.end("place_resolve", success: true)
-            NotificationCenter.default.post(name: .profileLocationDidUpdate, object: nil)
+            postProfileLocationDidUpdate(source: .placeNameResolved)
         } else {
             RuntimePerformanceProbe.end("place_resolve", success: false, errorCode: "geocode_empty")
         }
@@ -829,7 +845,7 @@ final class AppSession: ObservableObject {
                 ),
                 accessToken: accessToken
             )
-            NotificationCenter.default.post(name: .profileLocationDidUpdate, object: nil)
+            postProfileLocationDidUpdate(source: .profileLocationSynced)
             return true
         } catch {
             return false
@@ -995,7 +1011,7 @@ final class AppSession: ObservableObject {
                     return .needsAuthentication
                 }
                 profileId = created.id
-                NotificationCenter.default.post(name: .profileLocationDidUpdate, object: nil)
+                postProfileLocationDidUpdate(source: .profileCreated)
                 lastProfileEnsureOutcome = .ready
                 lastProfileEnsureCompletedAt = Date()
                 ProductAnalytics.track(

--- a/mobile/ios/HiAir/Screens/DashboardView.swift
+++ b/mobile/ios/HiAir/Screens/DashboardView.swift
@@ -342,6 +342,7 @@ struct DashboardView: View {
             )
         }
         .onChange(of: session.locationRevision) { _ in
+            // Independent coordinate change — ensure still required when profile is empty.
             Task { await reloadDashboard() }
         }
         .onChange(of: session.displayPlaceName) { _ in
@@ -350,8 +351,10 @@ struct DashboardView: View {
         .onChange(of: healthService.connectionState) { newState in
             viewModel.wearableConnectionState = newState
         }
-        .onReceive(NotificationCenter.default.publisher(for: .profileLocationDidUpdate)) { _ in
-            Task { await reloadDashboard() }
+        .onReceive(NotificationCenter.default.publisher(for: .profileLocationDidUpdate)) { notification in
+            // Typed origin: foreground prepare already owned ensure; reload data only.
+            let skipEnsure = ProfileLocationUpdateContext.skipProfileEnsure(from: notification)
+            Task { await reloadDashboard(skipProfileEnsure: skipEnsure) }
         }
         .sheet(item: $activeInfoKey) { item in
             InfoTextSheet(text: session.l(item.id), closeTitle: session.l("common.close"))

--- a/mobile/ios/HiAir/Screens/DashboardView.swift
+++ b/mobile/ios/HiAir/Screens/DashboardView.swift
@@ -352,9 +352,15 @@ struct DashboardView: View {
             viewModel.wearableConnectionState = newState
         }
         .onReceive(NotificationCenter.default.publisher(for: .profileLocationDidUpdate)) { notification in
-            // Typed origin: foreground prepare already owned ensure; reload data only.
-            let skipEnsure = ProfileLocationUpdateContext.skipProfileEnsure(from: notification)
-            Task { await reloadDashboard(skipProfileEnsure: skipEnsure) }
+            // Re-evaluate skip inside the Task so a stale post after account switch cannot
+            // suppress ensure for the newly signed-in user.
+            Task {
+                let skipEnsure = ProfileLocationUpdateContext.skipProfileEnsure(
+                    from: notification,
+                    currentUserId: session.userId
+                )
+                await reloadDashboard(skipProfileEnsure: skipEnsure)
+            }
         }
         .sheet(item: $activeInfoKey) { item in
             InfoTextSheet(text: session.l(item.id), closeTitle: session.l("common.close"))

--- a/mobile/ios/HiAir/Services/LocationService.swift
+++ b/mobile/ios/HiAir/Services/LocationService.swift
@@ -87,6 +87,8 @@ extension Notification.Name {
 /// - Other sources: ensure was already handled by the publisher call chain, or profile is
 ///   already set. Independent coordinate changes use `locationRevision` (not this notification)
 ///   when a fresh ensure is required.
+/// - `userId` attributes the post to the session that owned the cycle; skip is honored only when
+///   it still matches the live session (blocks stale posts across logout / account switch).
 struct ProfileLocationUpdateContext: Equatable, Sendable {
     enum Source: String, Equatable, Sendable {
         case foregroundRefresh
@@ -96,6 +98,8 @@ struct ProfileLocationUpdateContext: Equatable, Sendable {
     }
 
     let source: Source
+    /// Account that owned the publisher call chain when the notification was posted.
+    let userId: String
 
     var skipProfileEnsureOnDashboardReload: Bool {
         switch source {
@@ -104,9 +108,17 @@ struct ProfileLocationUpdateContext: Equatable, Sendable {
         }
     }
 
-    static func skipProfileEnsure(from notification: Notification) -> Bool {
-        (notification.object as? ProfileLocationUpdateContext)?.skipProfileEnsureOnDashboardReload
-            ?? false
+    /// Skip ensure only when typed context says so **and** the attributed user still matches.
+    static func skipProfileEnsure(from notification: Notification, currentUserId: String) -> Bool {
+        guard let context = notification.object as? ProfileLocationUpdateContext else {
+            return false
+        }
+        let current = currentUserId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let attributed = context.userId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !current.isEmpty, !attributed.isEmpty, current == attributed else {
+            return false
+        }
+        return context.skipProfileEnsureOnDashboardReload
     }
 }
 

--- a/mobile/ios/HiAir/Services/LocationService.swift
+++ b/mobile/ios/HiAir/Services/LocationService.swift
@@ -79,6 +79,37 @@ extension Notification.Name {
     )
 }
 
+/// Typed origin for `.profileLocationDidUpdate`.
+///
+/// Profile ensure ownership:
+/// - `foregroundRefresh`: `prepareSessionForDataFetch` already owned ensure in this cycle —
+///   Dashboard must reload data only (`skipProfileEnsure`).
+/// - Other sources: ensure was already handled by the publisher call chain, or profile is
+///   already set. Independent coordinate changes use `locationRevision` (not this notification)
+///   when a fresh ensure is required.
+struct ProfileLocationUpdateContext: Equatable, Sendable {
+    enum Source: String, Equatable, Sendable {
+        case foregroundRefresh
+        case placeNameResolved
+        case profileLocationSynced
+        case profileCreated
+    }
+
+    let source: Source
+
+    var skipProfileEnsureOnDashboardReload: Bool {
+        switch source {
+        case .foregroundRefresh, .placeNameResolved, .profileLocationSynced, .profileCreated:
+            return true
+        }
+    }
+
+    static func skipProfileEnsure(from notification: Notification) -> Bool {
+        (notification.object as? ProfileLocationUpdateContext)?.skipProfileEnsureOnDashboardReload
+            ?? false
+    }
+}
+
 @MainActor
 protocol LocationProviding: AnyObject {
     var authorizationStatus: CLAuthorizationStatus { get }

--- a/mobile/ios/HiAirTests/ProfileEnsureTests.swift
+++ b/mobile/ios/HiAirTests/ProfileEnsureTests.swift
@@ -743,6 +743,104 @@ final class ProfileEnsureTests: XCTestCase {
         )
     }
 
+    func testAbandonedForegroundPrepareDoesNotSkipEnsureForReplacementAccount() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(200, object: []))
+        UITestMockAPIProtocol.responseDelayNanoseconds = 200_000_000
+        let session = harness.makeSession()
+        session.installAuthSession(
+            SupabaseAuthSession(
+                userId: "user-a",
+                email: "a@example.com",
+                accessToken: "token-a",
+                refreshToken: "refresh-a"
+            )
+        )
+        session.latitude = 41.28
+        session.longitude = 1.976
+        session.displayPlaceName = "Castelldefels"
+        session.profileId = ""
+
+        var postedContexts: [ProfileLocationUpdateContext] = []
+        let observer = NotificationCenter.default.addObserver(
+            forName: .profileLocationDidUpdate,
+            object: nil,
+            queue: nil
+        ) { notification in
+            if let context = notification.object as? ProfileLocationUpdateContext {
+                postedContexts.append(context)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        async let abandonedRefresh: Void = session.refreshOnForeground(
+            locationService: ImmediateCoordsLocationStub()
+        )
+        // Let user-a prepare/ensure start under delay.
+        for _ in 0..<100 {
+            if session.isEnsuringProfile { break }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 2_000_000)
+        }
+
+        session.installAuthSession(
+            SupabaseAuthSession(
+                userId: "user-b",
+                email: "b@example.com",
+                accessToken: "token-b",
+                refreshToken: "refresh-b"
+            )
+        )
+        session.latitude = 41.28
+        session.longitude = 1.976
+        session.displayPlaceName = "Castelldefels"
+        session.profileId = ""
+        session.resetForegroundRefreshDebounceForTests()
+
+        UITestMockAPIProtocol.setRoute(
+            method: "GET",
+            path: "/api/profiles",
+            response: .json(
+                200,
+                object: [[
+                    "id": "listed-b",
+                    "user_id": "user-b",
+                    "persona_type": "adult",
+                    "sensitivity_level": "medium",
+                    "home_lat": 41.28,
+                    "home_lon": 1.976,
+                    "date_of_birth": NSNull(),
+                    "age_years": NSNull(),
+                ]]
+            )
+        )
+        UITestMockAPIProtocol.responseDelayNanoseconds = 0
+
+        await abandonedRefresh
+        // Abandoned user-a foreground must not post a skip-eligible notification for user-b.
+        XCTAssertFalse(
+            postedContexts.contains {
+                $0.source == .foregroundRefresh && $0.userId == "user-b"
+            }
+        )
+        XCTAssertFalse(
+            postedContexts.contains {
+                $0.source == .foregroundRefresh && $0.userId == "user-a"
+            },
+            "cancelled/abandoned owner must not emit foreground skip notification"
+        )
+
+        let prepared = await session.prepareSessionForDataFetch(
+            locationService: ImmediateCoordsLocationStub()
+        )
+        XCTAssertTrue(prepared.profileReady)
+        XCTAssertEqual(session.profileId, "listed-b")
+        // Replacement account must own a real ensure (not coalesce onto abandoned prepare).
+        XCTAssertGreaterThanOrEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+    }
+
     func testIndependentCoordinateChangeStillEnsuresOnce() async {
         // Callers audit: independent location updates go through locationRevision /
         // applyDeviceLocation → syncProfileLocationIfNeeded → ensure when profile empty.

--- a/mobile/ios/HiAirTests/ProfileEnsureTests.swift
+++ b/mobile/ios/HiAirTests/ProfileEnsureTests.swift
@@ -514,6 +514,20 @@ final class ProfileEnsureTests: XCTestCase {
         XCTAssertEqual(HiAirL10n.t("auth.sign_in", lang: "en"), "Sign in")
         XCTAssertFalse(HiAirL10n.t("profile.ensure.offline", lang: "ru").isEmpty)
         XCTAssertFalse(HiAirL10n.t("profile.ensure.offline", lang: "en").isEmpty)
+        XCTAssertTrue(HiAirL10n.t("profile.ensure.unavailable", lang: "ru").contains("временно"))
+        XCTAssertTrue(HiAirL10n.t("profile.ensure.unavailable", lang: "en").lowercased().contains("unavailable"))
+    }
+
+    func testLocationRecoveryOnlyForNeedsLocationCategory() {
+        XCTAssertTrue(ProfileEnsureOutcome.needsLocation.suggestsLocationRecovery)
+        XCTAssertEqual(ProfileEnsureOutcome.needsLocation.category, .location)
+        XCTAssertFalse(ProfileEnsureOutcome.failure(.unavailable).suggestsLocationRecovery)
+        XCTAssertEqual(ProfileEnsureOutcome.failure(.unavailable).category, .server)
+        XCTAssertTrue(ProfileEnsureOutcome.failure(.unavailable).suggestsNetworkRetry)
+        XCTAssertFalse(ProfileEnsureOutcome.failure(.offline).suggestsLocationRecovery)
+        XCTAssertTrue(ProfileEnsureOutcome.failure(.offline).suggestsNetworkRetry)
+        XCTAssertFalse(ProfileEnsureOutcome.failure(.cancelled).suggestsLocationRecovery)
+        XCTAssertFalse(ProfileEnsureOutcome.needsAuthentication.suggestsLocationRecovery)
     }
 
     func testNormalizedPersonaAndSensitivity() {

--- a/mobile/ios/HiAirTests/ProfileEnsureTests.swift
+++ b/mobile/ios/HiAirTests/ProfileEnsureTests.swift
@@ -530,6 +530,282 @@ final class ProfileEnsureTests: XCTestCase {
         XCTAssertFalse(ProfileEnsureOutcome.needsAuthentication.suggestsLocationRecovery)
     }
 
+    // MARK: - Foreground cycle: ensure-once (TF 159 P1)
+
+    /// Mirrors Dashboard `.onReceive(.profileLocationDidUpdate)` ensure decision.
+    @discardableResult
+    private func simulateDashboardProfileLocationReload(
+        session: AppSession,
+        notification: Notification
+    ) async -> ProfileEnsureOutcome? {
+        let skip = ProfileLocationUpdateContext.skipProfileEnsure(from: notification)
+        guard !skip, session.profileId.isEmpty else { return nil }
+        return await session.ensureProfileIdIfNeeded()
+    }
+
+    func testForegroundEnsureFailureDoesNotDoubleEnsureViaLocationNotification() async {
+        UITestMockAPIProtocol.reset(
+            listProfiles: .json(500, object: ["detail": "boom"])
+        )
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.refreshToken = "refresh"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        // Avoid async place-resolve noise during prepare; P1 is ensure ownership.
+        session.displayPlaceName = "Castelldefels"
+
+        var sources: [ProfileLocationUpdateContext.Source] = []
+        var secondEnsureFired = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .profileLocationDidUpdate,
+            object: nil,
+            queue: nil
+        ) { notification in
+            let context = notification.object as? ProfileLocationUpdateContext
+            if let source = context?.source {
+                sources.append(source)
+            }
+            XCTAssertTrue(
+                ProfileLocationUpdateContext.skipProfileEnsure(from: notification),
+                "post-prepare location notifications must skip ensure"
+            )
+            Task { @MainActor in
+                let outcome = await self.simulateDashboardProfileLocationReload(
+                    session: session,
+                    notification: notification
+                )
+                if outcome != nil {
+                    secondEnsureFired = true
+                }
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        await session.refreshOnForeground(locationService: ImmediateCoordsLocationStub())
+        // Allow notification handler tasks to settle.
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(sources.contains(.foregroundRefresh))
+        XCTAssertFalse(secondEnsureFired, "Dashboard must not start a second ensure after foreground prepare")
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1,
+            "exactly one list ensure in the foreground cycle"
+        )
+        XCTAssertEqual(session.lastProfileEnsureOutcome, .failure(.server))
+        XCTAssertEqual(session.lastProfileEnsurePhase, .list)
+        XCTAssertEqual(session.lastProfileEnsureOutcome?.diagnosticCode, "PE_HTTP_5XX")
+        XCTAssertNotEqual(session.lastProfileEnsureOutcome?.diagnosticCode, "PE_NET_TRANSPORT")
+        XCTAssertEqual(session.profileEnsureUserMessage, session.l("profile.ensure.failed"))
+    }
+
+    func testForegroundEnsureSuccessNotificationReloadsWithoutSecondEnsure() async {
+        UITestMockAPIProtocol.reset(
+            listProfiles: .json(
+                200,
+                object: [[
+                    "id": "listed-1",
+                    "user_id": "user-1",
+                    "persona_type": "adult",
+                    "sensitivity_level": "medium",
+                    "home_lat": 41.28,
+                    "home_lon": 1.976,
+                    "date_of_birth": NSNull(),
+                    "age_years": NSNull(),
+                ]]
+            )
+        )
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.refreshToken = "refresh"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        session.displayPlaceName = "Castelldefels"
+
+        var sawForegroundRefresh = false
+        var notificationEnsureAttempts = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: .profileLocationDidUpdate,
+            object: nil,
+            queue: nil
+        ) { notification in
+            if (notification.object as? ProfileLocationUpdateContext)?.source == .foregroundRefresh {
+                sawForegroundRefresh = true
+            }
+            Task { @MainActor in
+                if await self.simulateDashboardProfileLocationReload(
+                    session: session,
+                    notification: notification
+                ) != nil {
+                    notificationEnsureAttempts += 1
+                }
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        await session.refreshOnForeground(locationService: ImmediateCoordsLocationStub())
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertTrue(sawForegroundRefresh, "downstream dashboard reload signal must still fire")
+        XCTAssertEqual(notificationEnsureAttempts, 0)
+        XCTAssertEqual(session.profileId, "listed-1")
+        XCTAssertEqual(session.lastProfileEnsureOutcome, .ready)
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "POST"),
+            0
+        )
+    }
+
+    func testIndependentCoordinateChangeStillEnsuresOnce() async {
+        // Callers audit: independent location updates go through locationRevision /
+        // applyDeviceLocation → syncProfileLocationIfNeeded → ensure when profile empty.
+        // `.profileLocationDidUpdate` is not the owner of that ensure.
+        UITestMockAPIProtocol.reset(listProfiles: .json(200, object: []))
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.refreshToken = "refresh"
+        session.profileId = ""
+        session.latitude = 0
+        session.longitude = 0
+
+        var notificationEnsureAttempts = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: .profileLocationDidUpdate,
+            object: nil,
+            queue: nil
+        ) { notification in
+            Task { @MainActor in
+                if await self.simulateDashboardProfileLocationReload(
+                    session: session,
+                    notification: notification
+                ) != nil {
+                    notificationEnsureAttempts += 1
+                }
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let applied = await session.applyDeviceLocation(lat: 41.28, lon: 1.976)
+        XCTAssertTrue(applied)
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertFalse(session.profileId.isEmpty)
+        XCTAssertEqual(notificationEnsureAttempts, 0, "notification path must not add a second ensure")
+        // One ensure from syncProfileLocationIfNeeded (list→create).
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "POST"),
+            1
+        )
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+    }
+
+    func testNewForegroundCycleCanEnsureAgainWithoutWallClockWait() async {
+        UITestMockAPIProtocol.reset(
+            listProfiles: .json(500, object: ["detail": "boom"])
+        )
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.refreshToken = "refresh"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+
+        await session.refreshOnForeground(locationService: ImmediateCoordsLocationStub())
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+        XCTAssertEqual(session.lastProfileEnsureOutcome, .failure(.server))
+
+        // Ownership reset for a new cycle — not a wall-clock debounce workaround for double-ensure.
+        session.resetForegroundRefreshDebounceForTests()
+        UITestMockAPIProtocol.setRoute(
+            method: "GET",
+            path: "/api/profiles",
+            response: .json(
+                200,
+                object: [[
+                    "id": "listed-cycle-2",
+                    "user_id": "user-1",
+                    "persona_type": "adult",
+                    "sensitivity_level": "medium",
+                    "home_lat": 41.28,
+                    "home_lon": 1.976,
+                    "date_of_birth": NSNull(),
+                    "age_years": NSNull(),
+                ]]
+            )
+        )
+        await session.refreshOnForeground(locationService: ImmediateCoordsLocationStub())
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            2,
+            "a later real refresh-cycle may run a new ensure"
+        )
+        XCTAssertEqual(session.profileId, "listed-cycle-2")
+        XCTAssertEqual(session.lastProfileEnsureOutcome, .ready)
+    }
+
+    func testConcurrentPrepareInSameCycleSingleFlightsEnsure() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(200, object: []))
+        UITestMockAPIProtocol.responseDelayNanoseconds = 80_000_000
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        let location = ImmediateCoordsLocationStub()
+        async let first = session.prepareSessionForDataFetch(locationService: location)
+        async let second = session.prepareSessionForDataFetch(locationService: location)
+        let a = await first
+        let b = await second
+        XCTAssertTrue(a.profileReady)
+        XCTAssertTrue(b.profileReady)
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "POST"),
+            1
+        )
+    }
+
+    func testLegacyNilNotificationObjectDoesNotSkipEnsure() async {
+        // Untyped posts (object nil) keep prior behavior — ensure still runs when profile empty.
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        UITestMockAPIProtocol.reset(
+            listProfiles: .json(503, object: ["detail": "busy"])
+        )
+        let note = Notification(name: .profileLocationDidUpdate, object: nil)
+        XCTAssertFalse(ProfileLocationUpdateContext.skipProfileEnsure(from: note))
+        let outcome = await simulateDashboardProfileLocationReload(session: session, notification: note)
+        XCTAssertEqual(outcome, .failure(.unavailable))
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+    }
+
     func testNormalizedPersonaAndSensitivity() {
         XCTAssertEqual(AppSession.normalizedPersona("ASTHMA"), "asthma")
         XCTAssertEqual(AppSession.normalizedPersona("general"), "adult")

--- a/mobile/ios/HiAirTests/ProfileEnsureTests.swift
+++ b/mobile/ios/HiAirTests/ProfileEnsureTests.swift
@@ -538,7 +538,10 @@ final class ProfileEnsureTests: XCTestCase {
         session: AppSession,
         notification: Notification
     ) async -> ProfileEnsureOutcome? {
-        let skip = ProfileLocationUpdateContext.skipProfileEnsure(from: notification)
+        let skip = ProfileLocationUpdateContext.skipProfileEnsure(
+            from: notification,
+            currentUserId: session.userId
+        )
         guard !skip, session.profileId.isEmpty else { return nil }
         return await session.ensureProfileIdIfNeeded()
     }
@@ -568,9 +571,13 @@ final class ProfileEnsureTests: XCTestCase {
             if let source = context?.source {
                 sources.append(source)
             }
+            XCTAssertEqual(context?.userId, "user-1")
             XCTAssertTrue(
-                ProfileLocationUpdateContext.skipProfileEnsure(from: notification),
-                "post-prepare location notifications must skip ensure"
+                ProfileLocationUpdateContext.skipProfileEnsure(
+                    from: notification,
+                    currentUserId: "user-1"
+                ),
+                "post-prepare location notifications must skip ensure for the owning user"
             )
             Task { @MainActor in
                 let outcome = await self.simulateDashboardProfileLocationReload(
@@ -664,6 +671,75 @@ final class ProfileEnsureTests: XCTestCase {
         XCTAssertEqual(
             UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "POST"),
             0
+        )
+    }
+
+    func testStaleForegroundRefreshNotificationDoesNotSkipEnsureAfterAccountSwitch() async {
+        UITestMockAPIProtocol.reset(
+            listProfiles: .json(
+                200,
+                object: [[
+                    "id": "listed-b",
+                    "user_id": "user-b",
+                    "persona_type": "adult",
+                    "sensitivity_level": "medium",
+                    "home_lat": 41.28,
+                    "home_lon": 1.976,
+                    "date_of_birth": NSNull(),
+                    "age_years": NSNull(),
+                ]]
+            )
+        )
+        let session = harness.makeSession()
+        session.installAuthSession(
+            SupabaseAuthSession(
+                userId: "user-a",
+                email: "a@example.com",
+                accessToken: "token-a",
+                refreshToken: "refresh-a"
+            )
+        )
+        session.latitude = 41.28
+        session.longitude = 1.976
+        session.displayPlaceName = "Castelldefels"
+        session.profileId = ""
+
+        // Stale post attributed to user-a, delivered after switch to user-b.
+        let staleNotification = Notification(
+            name: .profileLocationDidUpdate,
+            object: ProfileLocationUpdateContext(source: .foregroundRefresh, userId: "user-a")
+        )
+
+        session.installAuthSession(
+            SupabaseAuthSession(
+                userId: "user-b",
+                email: "b@example.com",
+                accessToken: "token-b",
+                refreshToken: "refresh-b"
+            )
+        )
+        session.latitude = 41.28
+        session.longitude = 1.976
+        session.displayPlaceName = "Castelldefels"
+        XCTAssertTrue(session.profileId.isEmpty)
+
+        XCTAssertFalse(
+            ProfileLocationUpdateContext.skipProfileEnsure(
+                from: staleNotification,
+                currentUserId: session.userId
+            ),
+            "foreign/stale attribution must not suppress ensure for the live session"
+        )
+
+        let outcome = await simulateDashboardProfileLocationReload(
+            session: session,
+            notification: staleNotification
+        )
+        XCTAssertEqual(outcome, .ready)
+        XCTAssertEqual(session.profileId, "listed-b")
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
         )
     }
 
@@ -797,7 +873,9 @@ final class ProfileEnsureTests: XCTestCase {
             listProfiles: .json(503, object: ["detail": "busy"])
         )
         let note = Notification(name: .profileLocationDidUpdate, object: nil)
-        XCTAssertFalse(ProfileLocationUpdateContext.skipProfileEnsure(from: note))
+        XCTAssertFalse(
+            ProfileLocationUpdateContext.skipProfileEnsure(from: note, currentUserId: session.userId)
+        )
         let outcome = await simulateDashboardProfileLocationReload(session: session, notification: note)
         XCTAssertEqual(outcome, .failure(.unavailable))
         XCTAssertEqual(

--- a/mobile/ios/HiAirUITests/ProfileBootstrapUITests.swift
+++ b/mobile/ios/HiAirUITests/ProfileBootstrapUITests.swift
@@ -37,7 +37,6 @@ final class ProfileBootstrapUITests: XCTestCase {
         let app = UITestLaunch.launch(seedLocation: false, extraEnvironment: [
             "UITEST_SEED_LOCATION": "0",
         ])
-        // Explicitly clear coords by not seeding; also force zeros via env absence.
         attachScreenshot(app, name: "03-needs-location-before")
 
         let cta = waitForIdentifier(app, "dashboard.create_profile", timeout: 10)
@@ -48,6 +47,34 @@ final class ProfileBootstrapUITests: XCTestCase {
         attachA11yDump(app, name: "03-needs-location-after")
         XCTAssertTrue(error.exists)
         XCTAssertTrue(cta.exists, "CTA remains for retry when location missing")
+
+        // Location-only recovery: stable a11y id, hittable, correct RU semantics.
+        let locationCTA = waitForIdentifier(app, "profile_ensure.location_action", timeout: 3)
+        XCTAssertTrue(locationCTA.exists, "needsLocation must show location recovery action")
+        XCTAssertTrue(locationCTA.isHittable, "location recovery must be actionable")
+        XCTAssertTrue(
+            locationCTA.label.contains("Повторить") || locationCTA.label.lowercased().contains("retry"),
+            "location recovery label must be location.retry localization"
+        )
+        let errorText = error.label.lowercased()
+        XCTAssertTrue(
+            errorText.contains("геолокац") || errorText.contains("location"),
+            "error must be needs_location copy, not generic network"
+        )
+        XCTAssertFalse(
+            errorText.contains("соединен") || errorText.contains("connection"),
+            "needsLocation must not surface generic connection failure copy"
+        )
+
+        // Tap must invoke recovery path (bootstrap + ensure), not hang or vanish controls.
+        locationCTA.tap()
+        _ = app.descendants(matching: .any)["profile_ensure.loading"].waitForExistence(timeout: 2)
+        let errorAfter = app.descendants(matching: .any)["profile_ensure.error"]
+        let ctaAfter = app.descendants(matching: .any)["dashboard.create_profile"]
+        XCTAssertTrue(
+            errorAfter.exists || ctaAfter.exists || locationCTA.exists,
+            "after location recovery tap, recoverable UI must remain"
+        )
     }
 
     func testCreateProfileShowsUnavailableOn503() throws {
@@ -60,6 +87,56 @@ final class ProfileBootstrapUITests: XCTestCase {
         attachScreenshot(app, name: "05-profile-503")
         XCTAssertTrue(error.exists)
         XCTAssertTrue(cta.exists)
+
+        // Server failure keeps retry primary CTA and must NOT offer location recovery.
+        let locationCTA = app.descendants(matching: .any)["profile_ensure.location_action"]
+        XCTAssertFalse(
+            locationCTA.waitForExistence(timeout: 1),
+            "503/unavailable must not offer location recovery CTA"
+        )
+        let errorText = error.label.lowercased()
+        XCTAssertTrue(
+            errorText.contains("временно недоступен") || errorText.contains("temporarily unavailable"),
+            "503 must show unavailable/retry messaging"
+        )
+        XCTAssertTrue(
+            cta.label.contains("Повторить") || cta.label.lowercased().contains("retry"),
+            "503 primary CTA must be profile.ensure.retry, not create-only copy"
+        )
+        XCTAssertFalse(
+            errorText.contains("геолокац") || errorText.contains("location is required"),
+            "503 must not be misclassified as needsLocation"
+        )
+    }
+
+    func testNeedsLocationRecoveryCTAInEnglish() throws {
+        let app = UITestLaunch.launch(
+            language: "en",
+            seedLocation: false,
+            extraEnvironment: ["UITEST_SEED_LOCATION": "0"]
+        )
+        let cta = waitForIdentifier(app, "dashboard.create_profile", timeout: 10)
+        cta.tap()
+        let error = waitForIdentifier(app, "profile_ensure.error", timeout: 8)
+        XCTAssertTrue(error.label.lowercased().contains("location"))
+        let locationCTA = waitForIdentifier(app, "profile_ensure.location_action", timeout: 3)
+        XCTAssertTrue(locationCTA.isHittable)
+        XCTAssertTrue(locationCTA.label.lowercased().contains("retry"))
+    }
+
+    func testUnavailable503HasNoLocationCTAInEnglish() throws {
+        let app = UITestLaunch.launch(
+            language: "en",
+            extraEnvironment: ["UITEST_PROFILES_STATUS": "503"]
+        )
+        let cta = waitForIdentifier(app, "dashboard.create_profile")
+        cta.tap()
+        let error = waitForIdentifier(app, "profile_ensure.error", timeout: 8)
+        XCTAssertTrue(error.label.lowercased().contains("unavailable"))
+        XCTAssertTrue(cta.label.lowercased().contains("retry"))
+        XCTAssertFalse(
+            app.descendants(matching: .any)["profile_ensure.location_action"].waitForExistence(timeout: 1)
+        )
     }
 
     func testCreateProfileUnauthorizedReturnsToAuth() throws {


### PR DESCRIPTION
## Summary

Fixes physical TestFlight **0.1.0 (159)** P1 `FAILED_P1_PROFILE_DOUBLE_ENSURE`.

### Physical reproduction (TF 159)

On cold launch after overlay 149→159:

1. `refreshOnForeground` → `prepareSessionForDataFetch` → profile ensure
2. First ensure: `PE_HTTP_5XX` / `phase=list` / HTTP 500
3. Prepare finishes; entitlement refresh runs; posts `.profileLocationDidUpdate` (nil object)
4. Dashboard `.onReceive` → `reloadDashboard()` **without** `skipProfileEnsure`
5. Second ensure ~3.7s later: `PE_NET_TRANSPORT` / `invalid_url`
6. Sticky UI overwrites the first typed failure with transport copy

Sanitized historical evidence (do not rewrite):  
`.evidence/testflight-159-ios-qa/02-cold-launch/`  
Matrix stopped after P1: `.evidence/testflight-159-ios-qa/PHYSICAL-MATRIX.md`

### Root cause

One foreground refresh-cycle had two ensure owners: prepare (correct) and Dashboard reload after an untyped location notification (incorrect).

### Fix

Typed `ProfileLocationUpdateContext` on `.profileLocationDidUpdate`:

- `foregroundRefresh` (and other in-call-chain sources) → Dashboard `reloadDashboard(skipProfileEnsure: true)`
- Data reload still runs
- Independent coordinate changes keep ensure via `locationRevision` / `applyDeviceLocation` → `syncProfileLocationIfNeeded`
- Nil/unknown notification object → `skipProfileEnsure = false` (safe legacy / independent fallback)
- Not a wall-clock debounce or sticky global boolean; existing 8s foreground spam debounce is unchanged and unrelated

### Why independent location updates are preserved

Ensure-on-new-coords is owned by `locationRevision` and `syncProfileLocationIfNeeded`, not by the post-prepare notification.

### Local verification (not physical device)

| Gate | Result |
|------|--------|
| ProfileEnsure | 37 PASS |
| HiAirTests | 126 PASS |
| ProfileBootstrap UI | 6 PASS |
| HiAirUITests ×3 | 11 PASS ×3 |
| Release unsigned | SUCCEEDED |
| RU/EN ensure keys | OK |
| Simulator cold-launch (`UITEST_PROFILES_STATUS=500`) | 1× `PE_HTTP_5XX`; ensure count=1; `dashboard_refresh_succeeded`; no second ensure; no `invalid_url` |

Fix evidence summary: `.evidence/profile-double-ensure-fix/`

This PR has **not** been verified on a physical device with a new TestFlight binary.

### Explicit status

- **TF 159 remains failed** (historical physical evidence stands).
- **Physical matrix stopped after P1**; remaining cases were not run.
- **A new TestFlight build is required** after merge (build number TBD until ASC/Xcode Cloud confirms).
- **Remaining physical cases must be rerun from the beginning** on that new build.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: cut new iOS TestFlight (no assumed build #)
- [ ] Physical overlay cold launch: exactly one ensure terminal in first foreground cycle
- [ ] Confirm sticky UI keeps first typed failure (no secondary overwrite)
- [ ] Resume full physical matrix from row 1 on the new build
