### PR TITLE
fix(ios): enforce one profile ensure per foreground cycle

### DIFF
--- a/mobile/ios/HiAir.xcodeproj/project.pbxproj
+++ b/mobile/ios/HiAir.xcodeproj/project.pbxproj
@@ -581,6 +581,7 @@
 		13DE2FD2F4BB9D8A13D8E437 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				API_BASE_URL = "https://api.hiair.io";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = HiAir/HiAir.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -588,26 +589,13 @@
 				CURRENT_PROJECT_VERSION = 150;
 				DEVELOPMENT_TEAM = 43A4KW5BKB;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_API_BASE_URL = "https://api.hiair.io";
+				HIAIR_AUTH_REDIRECT_URI = "hiair://auth/callback";
+				INFOPLIST_FILE = HiAir/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = HiAir;
-				INFOPLIST_KEY_CFBundleURLTypes = (
-					{
-						CFBundleURLName = com.hiair.app.auth;
-						CFBundleURLSchemes = (
-							hiair,
-						);
-					},
-				);
-				INFOPLIST_KEY_HIAIR_AUTH_REDIRECT_URI = "hiair://auth/callback";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				INFOPLIST_KEY_LSApplicationQueriesSchemes = (
-					"x-apple-health",
-				);
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HiAir reads activity, heart, sleep, breathing, temperature, and related Apple Health summaries to personalize air and heat wellness guidance. HiAir does not diagnose or treat medical conditions.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "HiAir connects to Apple Health to read wellness summaries for personal activity and recovery insights. HiAir does not write health data to Apple Health.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "HiAir uses your location to estimate heat and air-quality risk for your current area and personalize local guidance.";
-				INFOPLIST_KEY_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw";
-				INFOPLIST_KEY_SUPABASE_URL = "https://qhxesaemlhzwbunpqjoo.supabase.co";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
@@ -622,6 +610,8 @@
 				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hiair.app;
 				SDKROOT = iphoneos;
+				SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw";
+				SUPABASE_URL = "https://qhxesaemlhzwbunpqjoo.supabase.co";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -670,6 +660,7 @@
 		97AC12AFF3260904AD792FD2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				API_BASE_URL = "http://127.0.0.1:8000";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGNING_ALLOWED[sdk=iphoneos*]" = NO;
 				"CODE_SIGNING_REQUIRED[sdk=iphoneos*]" = NO;
@@ -679,27 +670,14 @@
 				CURRENT_PROJECT_VERSION = 150;
 				DEVELOPMENT_TEAM = 43A4KW5BKB;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_API_BASE_URL = "http://127.0.0.1:8000";
+				HIAIR_AUTH_REDIRECT_URI = "hiair://auth/callback";
+				INFOPLIST_FILE = HiAir/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = HiAir;
-				INFOPLIST_KEY_CFBundleURLTypes = (
-					{
-						CFBundleURLName = com.hiair.app.auth;
-						CFBundleURLSchemes = (
-							hiair,
-						);
-					},
-				);
-				INFOPLIST_KEY_HIAIR_AUTH_REDIRECT_URI = "hiair://auth/callback";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
-				INFOPLIST_KEY_LSApplicationQueriesSchemes = (
-					"x-apple-health",
-				);
 				INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoads = YES;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "HiAir reads activity, heart, sleep, breathing, temperature, and related Apple Health summaries to personalize air and heat wellness guidance. HiAir does not diagnose or treat medical conditions.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "HiAir connects to Apple Health to read wellness summaries for personal activity and recovery insights. HiAir does not write health data to Apple Health.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "HiAir uses your location to estimate heat and air-quality risk for your current area and personalize local guidance.";
-				INFOPLIST_KEY_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw";
-				INFOPLIST_KEY_SUPABASE_URL = "https://qhxesaemlhzwbunpqjoo.supabase.co";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIRequiresFullScreen = YES;
@@ -714,6 +692,8 @@
 				MARKETING_VERSION = 0.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hiair.app;
 				SDKROOT = iphoneos;
+				SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw";
+				SUPABASE_URL = "https://qhxesaemlhzwbunpqjoo.supabase.co";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/mobile/ios/HiAir.xcodeproj/project.pbxproj
+++ b/mobile/ios/HiAir.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		5740C62DFDE5A26DFA327001 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D1E2C509CFB15ACA399B3D /* SettingsView.swift */; };
 		5B71DE90A4457E575BBEC07C /* HiAirMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB46A64A9D06988894EB3978 /* HiAirMotion.swift */; };
 		611512163246F5F671FAAFE7 /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C80D922CB3152908E2D2892 /* LocationService.swift */; };
+		620932E297A0EFA3FE5AA010 /* InfoPlistPackagingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFBA10AF3A09D3861286628 /* InfoPlistPackagingTests.swift */; };
 		622F96C121C55BFEDC2ACA92 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5E2B65A2779082CBA2B644 /* KeychainStore.swift */; };
 		630FD44D484D2D68453486A9 /* ProfileEnsureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAE1DA0A37DFC548AF3687D /* ProfileEnsureTests.swift */; };
 		714BB4A2D60C45C93C508CFD /* PaywallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473FF9ADA6A471A1B256FE84 /* PaywallView.swift */; };
@@ -153,6 +154,7 @@
 		C19DE8CB0A73BCBFB52D37CE /* HiAirSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirSpacing.swift; sourceTree = "<group>"; };
 		C4B6014D57E717DDEFDA1D47 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		C556E4BD33D299DF71C4B0E6 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		CCFBA10AF3A09D3861286628 /* InfoPlistPackagingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPlistPackagingTests.swift; sourceTree = "<group>"; };
 		CD19456D03A4B04C03A0348B /* HiAirHumanDateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirHumanDateTests.swift; sourceTree = "<group>"; };
 		CD6016001EE09F02386BE539 /* ProfileBootstrapUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileBootstrapUITests.swift; sourceTree = "<group>"; };
 		D45801250D377C4C9F87BCE9 /* UITestMockAPIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestMockAPIProtocol.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				AB03AB32DC5D272A4BCF0999 /* HealthKitAuthorizationSingleFlightTests.swift */,
 				8EDE901D8AA8E90B7F88CA47 /* HealthKitTimeoutRaceTests.swift */,
 				CD19456D03A4B04C03A0348B /* HiAirHumanDateTests.swift */,
+				CCFBA10AF3A09D3861286628 /* InfoPlistPackagingTests.swift */,
 				2DAE1DA0A37DFC548AF3687D /* ProfileEnsureTests.swift */,
 				5AC2FF57561B3EFDA6CC22DA /* RuntimeUXRecoveryTests.swift */,
 				E51B8943BC3F02E49B7FB4D0 /* SubscriptionServiceTests.swift */,
@@ -493,6 +496,7 @@
 				C1113FCF17266A966F5C04D3 /* HealthKitAuthorizationSingleFlightTests.swift in Sources */,
 				47FDE2DE4AB462EA0052DD48 /* HealthKitTimeoutRaceTests.swift in Sources */,
 				0B19571439FFB543F25751C6 /* HiAirHumanDateTests.swift in Sources */,
+				620932E297A0EFA3FE5AA010 /* InfoPlistPackagingTests.swift in Sources */,
 				630FD44D484D2D68453486A9 /* ProfileEnsureTests.swift in Sources */,
 				116362F5B5F2F56299C94173 /* RuntimeUXRecoveryTests.swift in Sources */,
 				1E1AE86A24B33D667114E29C /* SubscriptionServiceTests.swift in Sources */,

--- a/mobile/ios/HiAir/AppSession.swift
+++ b/mobile/ios/HiAir/AppSession.swift
@@ -122,12 +122,73 @@ final class AppSession: ObservableObject {
     private var suppressAPIClientAuthSync = false
     /// Bumped whenever an in-flight profile ensure must be abandoned (logout/auth switch).
     private var profileEnsureGeneration: UInt64 = 0
+    /// One data-fetch / foreground cycle may perform at most one underlying profile ensure attempt.
+    private var profileEnsureCycleGeneration: UInt64 = 0
+    private var profileEnsureCycleUserId: String = ""
+    private var profileEnsureCycleTerminal: ProfileEnsureOutcome?
+    /// Underlying ensure attempts in the active cycle (test seam + diagnostics).
+    private(set) var profileEnsureCycleAttemptCount: Int = 0
+    /// Location revisions observed while a prepare/ensure cycle is open (bootstrap must not open a new cycle).
+    private var profileEnsureCycleLocationRevisions: Set<Int> = []
+    private var prepareSessionNestingDepth: Int = 0
+
+    /// Explicit Retry / new foreground activation — opens a fresh ensure cycle.
+    func beginExplicitProfileEnsureCycle() {
+        profileEnsureCycleGeneration &+= 1
+        profileEnsureCycleUserId = userId.trimmingCharacters(in: .whitespacesAndNewlines)
+        profileEnsureCycleTerminal = nil
+        profileEnsureCycleAttemptCount = 0
+        profileEnsureCycleLocationRevisions = []
+        if locationRevision > 0 {
+            profileEnsureCycleLocationRevisions.insert(locationRevision)
+        }
+    }
+
+    private func openProfileEnsureCycleIfNeeded() {
+        let uid = userId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !uid.isEmpty else { return }
+        // Keep the active cycle for this user whether the ensure is in-flight or already terminal.
+        // Downstream callers (sibling Tab `.task`, locationRevision reload) must join / reuse —
+        // not open a fresh attempt after the first terminal result.
+        if profileEnsureCycleUserId == uid, profileEnsureCycleGeneration > 0 {
+            return
+        }
+        beginExplicitProfileEnsureCycle()
+    }
+
+    private func storeProfileEnsureCycleTerminal(_ outcome: ProfileEnsureOutcome) {
+        let uid = userId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !uid.isEmpty else { return }
+        if profileEnsureCycleGeneration == 0 || profileEnsureCycleUserId != uid {
+            openProfileEnsureCycleIfNeeded()
+        }
+        profileEnsureCycleTerminal = outcome
+        if locationRevision > 0 {
+            profileEnsureCycleLocationRevisions.insert(locationRevision)
+        }
+    }
+
+    private func memoizedProfileEnsureOutcomeForCurrentCycle() -> ProfileEnsureOutcome? {
+        let uid = userId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !uid.isEmpty,
+              profileEnsureCycleUserId == uid,
+              let terminal = profileEnsureCycleTerminal
+        else {
+            return nil
+        }
+        return terminal
+    }
 
     private func cancelInFlightProfileEnsure(clearOutcome: Bool) {
         profileEnsureGeneration &+= 1
         inFlightEnsureProfile?.cancel()
         inFlightEnsureProfile = nil
         isEnsuringProfile = false
+        profileEnsureCycleGeneration &+= 1
+        profileEnsureCycleUserId = ""
+        profileEnsureCycleTerminal = nil
+        profileEnsureCycleAttemptCount = 0
+        profileEnsureCycleLocationRevisions = []
         if clearOutcome {
             lastProfileEnsureOutcome = nil
         }
@@ -642,10 +703,13 @@ final class AppSession: ObservableObject {
             return await inFlightPrepare.value
         }
         let ownerUserId = userId.trimmingCharacters(in: .whitespacesAndNewlines)
+        openProfileEnsureCycleIfNeeded()
         let task = Task { @MainActor [weak self] () -> SessionPrepareResult in
             guard let self else {
                 return SessionPrepareResult(profileReady: false, locationReady: false, locationAttempted: false)
             }
+            self.prepareSessionNestingDepth += 1
+            defer { self.prepareSessionNestingDepth = max(0, self.prepareSessionNestingDepth - 1) }
             let abandoned = SessionPrepareResult(
                 profileReady: false,
                 locationReady: false,
@@ -717,6 +781,11 @@ final class AppSession: ObservableObject {
         let ownerUserId = userId.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !ownerUserId.isEmpty else { return }
         lastForegroundRefreshAt = now
+        // New foreground activation opens a new ensure cycle unless prepare is already in flight
+        // for this cold-start (join the existing cycle instead of wiping its memo).
+        if inFlightPrepare == nil {
+            beginExplicitProfileEnsureCycle()
+        }
         StartupDiagnostics.track("dashboard_refresh_started", errorCode: "foreground")
         _ = await prepareSessionForDataFetch(locationService: locationService)
         // Auth may have switched while prepare was in flight — never attribute to the new account.
@@ -816,6 +885,14 @@ final class AppSession: ObservableObject {
         longitude = lon
         locationSource = .device
         locationRevision += 1
+        // Bootstrap revisions belong to the open prepare/ensure cycle — do not start a new attempt.
+        if prepareSessionNestingDepth > 0 || inFlightEnsureProfile != nil || profileEnsureCycleTerminal == nil {
+            profileEnsureCycleLocationRevisions.insert(locationRevision)
+        } else if !profileEnsureCycleLocationRevisions.contains(locationRevision) {
+            // Post-terminal user/device move: legitimate new cycle.
+            beginExplicitProfileEnsureCycle()
+            profileEnsureCycleLocationRevisions.insert(locationRevision)
+        }
         // Geocode immediately — do not await profile PATCH / health / premium.
         Task { await self.resolvePlaceNameIfNeeded() }
         return await syncProfileLocationIfNeeded()
@@ -911,6 +988,11 @@ final class AppSession: ObservableObject {
 
     @discardableResult
     func ensureProfileIdIfNeeded() async -> ProfileEnsureOutcome {
+        openProfileEnsureCycleIfNeeded()
+        if let memoized = memoizedProfileEnsureOutcomeForCurrentCycle() {
+            lastProfileEnsureOutcome = memoized
+            return memoized
+        }
         if let inFlightEnsureProfile {
             return await inFlightEnsureProfile.value
         }
@@ -931,6 +1013,7 @@ final class AppSession: ObservableObject {
             lastProfileEnsurePhase = .idle
             lastProfileEnsureOutcome = .ready
             lastProfileEnsureCompletedAt = Date()
+            storeProfileEnsureCycleTerminal(.ready)
             return .ready
         }
         guard !userId.isEmpty, !accessToken.isEmpty else {
@@ -938,6 +1021,7 @@ final class AppSession: ObservableObject {
             lastProfileEnsurePhase = .list
             lastProfileEnsureOutcome = outcome
             lastProfileEnsureCompletedAt = Date()
+            storeProfileEnsureCycleTerminal(outcome)
             ProductAnalytics.track(
                 "profile_ensure_failed",
                 properties: ProfileEnsureMapper.analyticsProperties(
@@ -952,6 +1036,7 @@ final class AppSession: ObservableObject {
         let requestedUserId = userId
         var requestedAccessToken = accessToken
         let ensureGeneration = profileEnsureGeneration
+        profileEnsureCycleAttemptCount += 1
         isEnsuringProfile = true
         defer {
             if ensureGeneration == profileEnsureGeneration {
@@ -982,6 +1067,7 @@ final class AppSession: ObservableObject {
                 hydrateProfileLocation(from: existing)
                 lastProfileEnsureOutcome = .ready
                 lastProfileEnsureCompletedAt = Date()
+                storeProfileEnsureCycleTerminal(.ready)
                 ProductAnalytics.track(
                     "profile_ensure_succeeded",
                     properties: ["source": "list", "phase": phase.rawValue, "diagnostic_code": "PE_READY"]
@@ -1006,6 +1092,7 @@ final class AppSession: ObservableObject {
                 let outcome = ProfileEnsureOutcome.needsLocation
                 lastProfileEnsureOutcome = outcome
                 lastProfileEnsureCompletedAt = Date()
+                storeProfileEnsureCycleTerminal(outcome)
                 ProductAnalytics.track(
                     "profile_ensure_failed",
                     properties: ProfileEnsureMapper.analyticsProperties(
@@ -1048,6 +1135,7 @@ final class AppSession: ObservableObject {
                 postProfileLocationDidUpdate(source: .profileCreated)
                 lastProfileEnsureOutcome = .ready
                 lastProfileEnsureCompletedAt = Date()
+                storeProfileEnsureCycleTerminal(.ready)
                 ProductAnalytics.track(
                     "profile_ensure_succeeded",
                     properties: ["source": "create", "phase": phase.rawValue, "diagnostic_code": "PE_READY"]
@@ -1074,6 +1162,7 @@ final class AppSession: ObservableObject {
                     hydrateProfileLocation(from: existing)
                     lastProfileEnsureOutcome = .ready
                     lastProfileEnsureCompletedAt = Date()
+                    storeProfileEnsureCycleTerminal(.ready)
                     ProductAnalytics.track(
                         "profile_ensure_succeeded",
                         properties: [
@@ -1103,6 +1192,7 @@ final class AppSession: ObservableObject {
             lastProfileEnsureOutcome = outcome
             lastProfileEnsurePhase = phase
             lastProfileEnsureCompletedAt = Date()
+            storeProfileEnsureCycleTerminal(outcome)
             if case .needsAuthentication = outcome {
                 expireSessionAfterAuthFailure()
             } else if case .failure(let reason) = outcome, reason.suggestsReauthentication {

--- a/mobile/ios/HiAir/Info.plist
+++ b/mobile/ios/HiAir/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>HIAIR_AUTH_REDIRECT_URI</key>
 	<string>$(HIAIR_AUTH_REDIRECT_URI)</string>
 	<key>LSApplicationQueriesSchemes</key>

--- a/mobile/ios/HiAir/Info.plist
+++ b/mobile/ios/HiAir/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_BASE_URL</key>
+	<string>$(API_BASE_URL)</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.hiair.app.auth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>hiair</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>HIAIR_AUTH_REDIRECT_URI</key>
+	<string>$(HIAIR_AUTH_REDIRECT_URI)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>x-apple-health</string>
+	</array>
+	<key>SUPABASE_ANON_KEY</key>
+	<string>$(SUPABASE_ANON_KEY)</string>
+	<key>SUPABASE_URL</key>
+	<string>$(SUPABASE_URL)</string>
+</dict>
+</plist>

--- a/mobile/ios/HiAir/Models/ProfileEnsureOutcome.swift
+++ b/mobile/ios/HiAir/Models/ProfileEnsureOutcome.swift
@@ -271,6 +271,10 @@ enum ProfileEnsureMapper {
                 props["error_type"] = "api"
             case .invalidURL:
                 props["error_type"] = "invalid_url"
+                props["url_source"] = APIInvalidURLDiagnostics.lastSource.rawValue
+                props["url_has_scheme"] = APIInvalidURLDiagnostics.lastHasScheme ? "1" : "0"
+                props["url_has_host"] = APIInvalidURLDiagnostics.lastHasHost ? "1" : "0"
+                props["url_config_source"] = APIInvalidURLDiagnostics.lastConfigSource
             case .invalidResponse:
                 props["error_type"] = "invalid_response"
             }

--- a/mobile/ios/HiAir/Networking/APIClient.swift
+++ b/mobile/ios/HiAir/Networking/APIClient.swift
@@ -10,6 +10,41 @@ enum APIError: Error {
     case serverWithDetail(statusCode: Int, detail: String)
 }
 
+/// Safe origin for `APIError.invalidURL` diagnostics (no tokens / query / full URL).
+enum APIInvalidURLSource: String, Sendable {
+    case supabaseBaseMissing = "supabase_base_missing"
+    case supabaseComponentsFailed = "supabase_components_failed"
+    case apiComponentsFailed = "api_components_failed"
+    case unknown = "unknown"
+}
+
+enum APIInvalidURLDiagnostics {
+    /// Last invalidURL origin for the current process (test seam + Console props).
+    nonisolated(unsafe) static var lastSource: APIInvalidURLSource = .unknown
+    nonisolated(unsafe) static var lastHasScheme: Bool = false
+    nonisolated(unsafe) static var lastHasHost: Bool = false
+    nonisolated(unsafe) static var lastConfigSource: String = "none"
+
+    nonisolated static func record(
+        source: APIInvalidURLSource,
+        hasScheme: Bool = false,
+        hasHost: Bool = false,
+        configSource: String = "none"
+    ) {
+        lastSource = source
+        lastHasScheme = hasScheme
+        lastHasHost = hasHost
+        lastConfigSource = configSource
+    }
+
+    nonisolated static func resetForTests() {
+        lastSource = .unknown
+        lastHasScheme = false
+        lastHasHost = false
+        lastConfigSource = "none"
+    }
+}
+
 struct SupabaseAuthSession: Sendable {
     let userId: String
     let email: String
@@ -50,19 +85,97 @@ final class SupabaseAuthService: AuthRemoteSessionRevoking {
 
     /// Production singleton — reads Supabase config from the app bundle / process env.
     private convenience init() {
-        let info = Bundle.main.infoDictionary ?? [:]
-        let env = ProcessInfo.processInfo.environment
-        let rawURL = env["SUPABASE_URL"] ?? (info["SUPABASE_URL"] as? String) ?? ""
-        let anon = env["SUPABASE_ANON_KEY"] ?? (info["SUPABASE_ANON_KEY"] as? String) ?? ""
-        let redirect = env["HIAIR_AUTH_REDIRECT_URI"]
-            ?? (info["HIAIR_AUTH_REDIRECT_URI"] as? String)
-            ?? "hiair://auth/callback"
+        let resolved = Self.resolveSupabaseConfiguration()
         self.init(
             urlSession: .shared,
-            supabaseURL: URL(string: rawURL),
-            anonKey: anon,
-            redirectURI: redirect
+            supabaseURL: resolved.isValid ? resolved.url : nil,
+            anonKey: resolved.isValid ? resolved.anonKey : "",
+            redirectURI: resolved.redirectURI
         )
+    }
+
+    /// Atomically resolve Supabase URL + anon key from one source.
+    /// Empty/whitespace env values are unset (must not shadow plist).
+    /// A non-empty malformed env URL fails closed — never falls back to plist.
+    static func resolveSupabaseConfiguration(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary
+    ) -> (url: URL?, anonKey: String, redirectURI: String, configSource: String, isValid: Bool) {
+        let info = infoDictionary ?? [:]
+        let envURLRaw = environment["SUPABASE_URL"]
+        let envURL = nonEmptyTrimmed(envURLRaw)
+        let plistURL = nonEmptyTrimmed(info["SUPABASE_URL"] as? String)
+        let envKey = nonEmptyTrimmed(environment["SUPABASE_ANON_KEY"])
+        let plistKey = nonEmptyTrimmed(info["SUPABASE_ANON_KEY"] as? String)
+        let envRedirect = nonEmptyTrimmed(environment["HIAIR_AUTH_REDIRECT_URI"])
+        let plistRedirect = nonEmptyTrimmed(info["HIAIR_AUTH_REDIRECT_URI"] as? String)
+        let defaultRedirect = "hiair://auth/callback"
+
+        let configSource: String
+        let rawURL: String
+        let anon: String
+        let redirect: String
+        if envURLRaw != nil, nonEmptyTrimmed(envURLRaw) == nil {
+            // Present-but-empty / whitespace env → treat as unset, use plist pair.
+            if let plistURL {
+                rawURL = plistURL
+                anon = plistKey ?? ""
+                redirect = plistRedirect ?? defaultRedirect
+                configSource = "plist"
+            } else {
+                rawURL = ""
+                anon = ""
+                redirect = defaultRedirect
+                configSource = "none"
+            }
+        } else if let envURL {
+            // Non-empty env URL selects the env source atomically (no plist key mix-in).
+            rawURL = envURL
+            anon = envKey ?? ""
+            redirect = envRedirect ?? defaultRedirect
+            configSource = "env"
+        } else if let plistURL {
+            rawURL = plistURL
+            anon = plistKey ?? ""
+            redirect = plistRedirect ?? defaultRedirect
+            configSource = "plist"
+        } else {
+            rawURL = ""
+            anon = ""
+            redirect = defaultRedirect
+            configSource = "none"
+        }
+
+        let parsed = Self.parseHTTPSURL(rawURL)
+        let isValid = parsed != nil && !anon.isEmpty
+        if !isValid {
+            APIInvalidURLDiagnostics.record(
+                source: .supabaseBaseMissing,
+                hasScheme: URL(string: rawURL)?.scheme != nil,
+                hasHost: URL(string: rawURL)?.host != nil,
+                configSource: configSource
+            )
+        }
+        return (parsed, anon, redirect, configSource, isValid)
+    }
+
+    /// Accept only http(s) absolute URLs with a host. Malformed non-empty input → nil (fail closed).
+    private static func parseHTTPSURL(_ raw: String) -> URL? {
+        guard let url = URL(string: raw),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              let host = url.host,
+              !host.isEmpty
+        else {
+            return nil
+        }
+        return url
+    }
+
+    private static func nonEmptyTrimmed(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     /// DI seam for deterministic `URLSession` / `URLProtocol` tests. Production uses `shared`.
@@ -266,6 +379,10 @@ final class SupabaseAuthService: AuthRemoteSessionRevoking {
 
     private func openOAuth(provider: String) async throws {
         guard let base = supabaseURL else {
+            APIInvalidURLDiagnostics.record(
+                source: .supabaseBaseMissing,
+                configSource: "runtime"
+            )
             throw APIError.invalidURL
         }
         guard !anonKey.isEmpty else {
@@ -337,11 +454,26 @@ final class SupabaseAuthService: AuthRemoteSessionRevoking {
         bearerToken: String? = nil
     ) async throws -> Data {
         guard let base = supabaseURL else {
+            APIInvalidURLDiagnostics.record(
+                source: .supabaseBaseMissing,
+                configSource: "runtime"
+            )
             throw APIError.invalidURL
         }
-        var components = URLComponents(url: base.appending(path: path), resolvingAgainstBaseURL: false)
+        // Prefer relative path segments — leading "/" can break `appending(path:)` + URLComponents.
+        let normalizedPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+        var components = URLComponents(
+            url: base.appending(path: normalizedPath),
+            resolvingAgainstBaseURL: false
+        )
         components?.queryItems = query
         guard let url = components?.url else {
+            APIInvalidURLDiagnostics.record(
+                source: .supabaseComponentsFailed,
+                hasScheme: base.scheme != nil,
+                hasHost: base.host != nil,
+                configSource: "runtime"
+            )
             throw APIError.invalidURL
         }
         var request = URLRequest(url: url)

--- a/mobile/ios/HiAir/Networking/APIClient.swift
+++ b/mobile/ios/HiAir/Networking/APIClient.swift
@@ -474,6 +474,8 @@ final class APIClient {
 
     private let baseURL: URL
     private let session: URLSession
+    /// Test seam: when set, `listProfiles` throws before networking (TF164 `invalid_url` reproduction).
+    var testForceListProfilesError: Error?
 
     init(baseURL: URL, session: URLSession = .shared) {
         self.baseURL = baseURL
@@ -670,6 +672,9 @@ final class APIClient {
     }
 
     func listProfiles(userId: String, accessToken: String? = nil) async throws -> [UserProfile] {
+        if let testForceListProfilesError {
+            throw testForceListProfilesError
+        }
         let url = baseURL.appending(path: "/api/profiles")
         var request = URLRequest(url: url)
         request.httpMethod = "GET"

--- a/mobile/ios/HiAir/Screens/DailyPlannerView.swift
+++ b/mobile/ios/HiAir/Screens/DailyPlannerView.swift
@@ -173,6 +173,8 @@ struct DailyPlannerView: View {
                 Button(viewModel.loading ? session.l("planner.loading") : session.l("planner.refresh")) {
                     Task {
                         if session.profileId.isEmpty {
+                            // Explicit user refresh — do not reuse a prior terminal ensure failure.
+                            session.beginExplicitProfileEnsureCycle()
                             _ = await session.ensureProfileIdIfNeeded()
                         }
                         guard !session.profileId.isEmpty else {

--- a/mobile/ios/HiAir/Screens/DashboardView.swift
+++ b/mobile/ios/HiAir/Screens/DashboardView.swift
@@ -692,10 +692,12 @@ struct DashboardView: View {
             Button(viewModel.loading ? session.l("dashboard.loading") : session.l("dashboard.recompute")) {
                 Task {
                     if session.profileId.isEmpty {
+                        // Explicit user recompute — do not reuse a prior terminal ensure failure.
+                        session.beginExplicitProfileEnsureCycle()
                         _ = await session.ensureProfileIdIfNeeded()
                     }
                     session.markChecklistItem("risk", done: true)
-                    await reloadDashboard()
+                    await reloadDashboard(skipProfileEnsure: true)
                 }
             }
             .buttonStyle(HiAirSecondaryButtonStyle())

--- a/mobile/ios/HiAir/Screens/DashboardView.swift
+++ b/mobile/ios/HiAir/Screens/DashboardView.swift
@@ -284,7 +284,12 @@ struct DashboardView: View {
                             title: session.l("dashboard.error"),
                             message: session.l("dashboard.empty.api_unavailable"),
                             retryTitle: session.l("common.retry"),
-                            onRetry: { Task { await reloadDashboard() } }
+                            onRetry: {
+                                Task {
+                                    session.beginExplicitProfileEnsureCycle()
+                                    await reloadDashboard()
+                                }
+                            }
                         )
                         .v2Card()
                     } else if showLiveRiskContent {
@@ -305,7 +310,10 @@ struct DashboardView: View {
                 .hiAirScreenPadding(for: width)
                 .padding(.bottom, HiAirSpacing.xl)
             }
-            .refreshable { await reloadDashboard() }
+            .refreshable {
+                session.beginExplicitProfileEnsureCycle()
+                await reloadDashboard()
+            }
         }
         .hiAirPageBackground()
         .overlay {

--- a/mobile/ios/HiAir/Screens/InsightsView.swift
+++ b/mobile/ios/HiAir/Screens/InsightsView.swift
@@ -255,6 +255,8 @@ struct InsightsView: View {
                     Button(viewModel.loading ? session.l("insights.loading") : session.l("insights.refresh")) {
                         Task {
                             if session.profileId.isEmpty {
+                                // Explicit user refresh — do not reuse a prior terminal ensure failure.
+                                session.beginExplicitProfileEnsureCycle()
                                 _ = await session.ensureProfileIdIfNeeded()
                             }
                             guard !session.profileId.isEmpty else { return }

--- a/mobile/ios/HiAir/Screens/ProfileBootstrapCard.swift
+++ b/mobile/ios/HiAir/Screens/ProfileBootstrapCard.swift
@@ -136,6 +136,8 @@ struct ProfileBootstrapCard: View {
             || (session.lastProfileEnsureOutcome == nil && !session.hasValidLocation) {
             _ = await session.bootstrapLocationFromDevice(locationService: locationService)
         }
+        // Explicit Retry / CTA — new ensure cycle (must not reuse the prior terminal failure).
+        session.beginExplicitProfileEnsureCycle()
         let outcome = await session.ensureProfileIdIfNeeded()
         if outcome.isReady {
             session.markChecklistItem("profile", done: true)

--- a/mobile/ios/HiAir/Services/ProductAnalytics.swift
+++ b/mobile/ios/HiAir/Services/ProductAnalytics.swift
@@ -4,6 +4,8 @@ import os
 /// Events are written to unified logging for TestFlight / device Console capture.
 enum ProductAnalytics {
     private static let log = Logger(subsystem: "com.hiair.app", category: "product")
+    /// Test seam: captures sanitized events without PII (unit tests only).
+    nonisolated(unsafe) static var testEventSink: ((String, [String: String]) -> Void)?
 
     static func track(_ name: String, properties: [String: String] = [:]) {
         let sanitized = properties.filter { key, value in
@@ -12,6 +14,7 @@ enum ProductAnalytics {
                 && !key.lowercased().contains("user")
                 && !value.contains("@")
         }
+        testEventSink?(name, sanitized)
         if sanitized.isEmpty {
             log.info("\(name, privacy: .public)")
         } else {

--- a/mobile/ios/HiAir/TestingSupport/UITestMockAPIProtocol.swift
+++ b/mobile/ios/HiAir/TestingSupport/UITestMockAPIProtocol.swift
@@ -34,6 +34,11 @@ final class UITestMockAPIProtocol: URLProtocol, @unchecked Sendable {
     /// When set, the next matching request fails with this URLError (then cleared if oneShot).
     nonisolated(unsafe) static var failNextWithURLError: URLError.Code?
     nonisolated(unsafe) static var failURLErrorPathSubstring: String?
+    /// When set, matching request fails with this Error (e.g. `APIError.invalidURL`).
+    nonisolated(unsafe) static var failNextWithError: Error?
+    nonisolated(unsafe) static var failErrorPathSubstring: String?
+    /// When > 0, keep failing matching requests with `failNextWithError` that many times.
+    nonisolated(unsafe) static var failErrorRemainingCount: Int = 0
     private static let lock = NSLock()
 
     static func reset(
@@ -58,6 +63,9 @@ final class UITestMockAPIProtocol: URLProtocol, @unchecked Sendable {
         responseDelayNanoseconds = 0
         failNextWithURLError = nil
         failURLErrorPathSubstring = nil
+        failNextWithError = nil
+        failErrorPathSubstring = nil
+        failErrorRemainingCount = 0
         routes = [
             "GET /api/profiles": listProfiles,
             "POST /api/profiles": createProfile,
@@ -140,17 +148,33 @@ final class UITestMockAPIProtocol: URLProtocol, @unchecked Sendable {
         let key = "\(method) \(path)"
         let failCode = Self.failNextWithURLError
         let failPath = Self.failURLErrorPathSubstring
-        let shouldFail = failCode != nil && (failPath == nil || path.contains(failPath!))
-        if shouldFail {
+        let shouldFailURL = failCode != nil && (failPath == nil || path.contains(failPath!))
+        if shouldFailURL {
             Self.failNextWithURLError = nil
             Self.failURLErrorPathSubstring = nil
+        }
+        let failError = Self.failNextWithError
+        let failErrorPath = Self.failErrorPathSubstring
+        let shouldFailError = failError != nil
+            && Self.failErrorRemainingCount > 0
+            && (failErrorPath == nil || path.contains(failErrorPath!))
+        if shouldFailError {
+            Self.failErrorRemainingCount -= 1
+            if Self.failErrorRemainingCount <= 0 {
+                Self.failNextWithError = nil
+                Self.failErrorPathSubstring = nil
+            }
         }
         let response = Self.routes[key] ?? RouteResponse.json(404, object: ["detail": "unmocked \(key)"])
         let delay = Self.responseDelayNanoseconds
         Self.lock.unlock()
 
-        if shouldFail, let failCode {
+        if shouldFailURL, let failCode {
             client?.urlProtocol(self, didFailWithError: URLError(failCode))
+            return
+        }
+        if shouldFailError, let failError {
+            client?.urlProtocol(self, didFailWithError: failError)
             return
         }
 

--- a/mobile/ios/HiAirTests/InfoPlistPackagingTests.swift
+++ b/mobile/ios/HiAirTests/InfoPlistPackagingTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import XCTest
+@testable import HiAir
+
+/// Guards Release packaging: source Info.plist must derive versions from build settings,
+/// and the built app product must expand them (no unresolved `$(...)`).
+final class InfoPlistPackagingTests: XCTestCase {
+    func testSourceInfoPlistVersionsTrackBuildSettings() throws {
+        let sourcePlist = try Self.locateSourceInfoPlist()
+        let data = try Data(contentsOf: sourcePlist)
+        let object = try PropertyListSerialization.propertyList(from: data, options: [], format: nil)
+        guard let dict = object as? [String: Any] else {
+            return XCTFail("Info.plist root must be a dictionary")
+        }
+        XCTAssertEqual(
+            dict["CFBundleShortVersionString"] as? String,
+            "$(MARKETING_VERSION)",
+            "source Info.plist must not hard-code marketing version (ASC/TF regression risk)"
+        )
+        XCTAssertEqual(
+            dict["CFBundleVersion"] as? String,
+            "$(CURRENT_PROJECT_VERSION)",
+            "source Info.plist must not hard-code build number (ASC/TF regression risk)"
+        )
+        XCTAssertEqual(dict["CFBundleIdentifier"] as? String, "$(PRODUCT_BUNDLE_IDENTIFIER)")
+        XCTAssertNotNil(dict["SUPABASE_URL"] as? String)
+        XCTAssertNotNil(dict["SUPABASE_ANON_KEY"] as? String)
+        XCTAssertNotNil(dict["API_BASE_URL"] as? String)
+        let urlTypes = dict["CFBundleURLTypes"] as? [[String: Any]]
+        let schemes = urlTypes?.first?["CFBundleURLSchemes"] as? [String]
+        XCTAssertEqual(schemes, ["hiair"])
+        XCTAssertEqual(dict["LSApplicationQueriesSchemes"] as? [String], ["x-apple-health"])
+    }
+
+    func testBuiltProductInfoPlistHasExpandedRuntimeKeys() throws {
+        let info = Bundle.main.infoDictionary
+        XCTAssertEqual(info?["CFBundleIdentifier"] as? String, "com.hiair.app")
+        let marketing = try XCTUnwrap(info?["CFBundleShortVersionString"] as? String)
+        let build = try XCTUnwrap(info?["CFBundleVersion"] as? String)
+        XCTAssertFalse(marketing.contains("$("), "unresolved marketing version: \(marketing)")
+        XCTAssertFalse(build.contains("$("), "unresolved build number: \(build)")
+        XCTAssertFalse(marketing.isEmpty)
+        XCTAssertFalse(build.isEmpty)
+        XCTAssertNotEqual(marketing, "1.0", "Release product must use MARKETING_VERSION (0.1.0), not plist default 1.0")
+        XCTAssertNotEqual(build, "1", "Release product must use CURRENT_PROJECT_VERSION, not plist default 1")
+
+        let supabaseURL = try XCTUnwrap(info?["SUPABASE_URL"] as? String)
+        let apiBase = try XCTUnwrap(info?["API_BASE_URL"] as? String)
+        let anon = try XCTUnwrap(info?["SUPABASE_ANON_KEY"] as? String)
+        XCTAssertFalse(supabaseURL.contains("$("))
+        XCTAssertFalse(apiBase.contains("$("))
+        XCTAssertFalse(anon.contains("$("))
+        XCTAssertFalse(anon.lowercased().contains("service_role"))
+        XCTAssertFalse(anon.contains("sb_secret"))
+
+        let urlTypes = info?["CFBundleURLTypes"] as? [[String: Any]]
+        let schemes = urlTypes?.compactMap { $0["CFBundleURLSchemes"] as? [String] }.flatMap { $0 } ?? []
+        XCTAssertTrue(schemes.contains("hiair"), "auth URL scheme missing from product Info.plist")
+        let queries = info?["LSApplicationQueriesSchemes"] as? [String] ?? []
+        XCTAssertTrue(queries.contains("x-apple-health"))
+
+        XCTAssertNotNil(info?["NSHealthShareUsageDescription"] as? String)
+        XCTAssertNotNil(info?["NSHealthUpdateUsageDescription"] as? String)
+        XCTAssertNotNil(info?["NSLocationWhenInUseUsageDescription"] as? String)
+    }
+
+    private static func locateSourceInfoPlist() throws -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<6 {
+            url.deleteLastPathComponent()
+            let candidate = url.appendingPathComponent("HiAir/Info.plist")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+        }
+        throw XCTSkip("HiAir/Info.plist not found relative to test source")
+    }
+}

--- a/mobile/ios/HiAirTests/ProfileEnsureTests.swift
+++ b/mobile/ios/HiAirTests/ProfileEnsureTests.swift
@@ -11,12 +11,15 @@ final class ProfileEnsureTests: XCTestCase {
         try await super.setUp()
         APIClient.setAuthState(nil)
         APIClient.setAuthInvalidatedHandler(nil)
+        ProductAnalytics.testEventSink = nil
         harness = ProfileEnsureTestHarness()
         UITestMockAPIProtocol.isEnabled = true
         UITestMockAPIProtocol.reset()
     }
 
     override func tearDown() async throws {
+        ProductAnalytics.testEventSink = nil
+        harness?.apiClient.testForceListProfilesError = nil
         harness?.tearDown()
         harness = nil
         UITestMockAPIProtocol.isEnabled = false
@@ -453,6 +456,8 @@ final class ProfileEnsureTests: XCTestCase {
                 ]]
             )
         )
+        // Explicit Retry opens a new cycle (automatic post-failure ensure is memoized).
+        session.beginExplicitProfileEnsureCycle()
         async let r1 = session.ensureProfileIdIfNeeded()
         async let r2 = session.ensureProfileIdIfNeeded()
         let a = await r1
@@ -497,6 +502,7 @@ final class ProfileEnsureTests: XCTestCase {
                 ]]
             )
         )
+        session.beginExplicitProfileEnsureCycle()
         let ok = await session.ensureProfileIdIfNeeded()
         XCTAssertEqual(ok, .ready)
         XCTAssertFalse(session.isEnsuringProfile)
@@ -935,6 +941,341 @@ final class ProfileEnsureTests: XCTestCase {
         )
         XCTAssertEqual(session.profileId, "listed-cycle-2")
         XCTAssertEqual(session.lastProfileEnsureOutcome, .ready)
+    }
+
+    // MARK: - TF164 triple-trigger (cold launch Tab graph)
+
+    /// Mirrors Dashboard prepare + sibling Tab `.task` ensures after first terminal
+    /// (physical TF164: 3× `profile_ensure_failed` / `invalid_url` / `list`).
+    private func simulateTF164ColdLaunchEnsureGraph(session: AppSession) async {
+        let location = ImmediateCoordsLocationStub()
+        // Controllable scheduler: yield between triggers (no wall-clock sleep).
+        await session.prepareSessionForDataFetch(locationService: location)
+        await Task.yield()
+        // DailyPlannerView `.task` when profile empty
+        if session.profileId.isEmpty {
+            _ = await session.ensureProfileIdIfNeeded()
+        }
+        await Task.yield()
+        // InsightsView `.task` when profile empty
+        if session.profileId.isEmpty {
+            _ = await session.ensureProfileIdIfNeeded()
+        }
+        await Task.yield()
+        // Dashboard locationRevision reload (automatic — must not open a new cycle)
+        if session.profileId.isEmpty {
+            _ = await session.ensureProfileIdIfNeeded()
+        }
+    }
+
+    func testTF164TripleTriggerInvalidURLSingleEnsurePerCycle() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(200, object: []))
+        harness.apiClient.testForceListProfilesError = APIError.invalidURL
+
+        var failedEvents: [[String: String]] = []
+        ProductAnalytics.testEventSink = { name, props in
+            if name == "profile_ensure_failed" {
+                failedEvents.append(props)
+            }
+        }
+
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.refreshToken = "refresh"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        session.displayPlaceName = "Castelldefels"
+
+        await simulateTF164ColdLaunchEnsureGraph(session: session)
+
+        XCTAssertEqual(
+            session.profileEnsureCycleAttemptCount,
+            1,
+            "one underlying ensure attempt for the cold-launch cycle"
+        )
+        XCTAssertEqual(failedEvents.count, 1, "one terminal profile_ensure_failed emission")
+        XCTAssertEqual(failedEvents.first?["diagnostic_code"], "PE_NET_TRANSPORT")
+        XCTAssertEqual(failedEvents.first?["error_type"], "invalid_url")
+        XCTAssertEqual(failedEvents.first?["phase"], "list")
+        XCTAssertEqual(failedEvents.first?["reason"], "transport")
+        XCTAssertEqual(session.lastProfileEnsureOutcome, .failure(.transport))
+        XCTAssertEqual(session.lastProfileEnsurePhase, .list)
+        XCTAssertEqual(session.profileEnsureUserMessage, session.l("profile.ensure.transport"))
+        XCTAssertTrue(session.lastProfileEnsureOutcome?.suggestsNetworkRetry == true)
+        XCTAssertFalse(session.lastProfileEnsureOutcome?.suggestsLocationRecovery == true)
+        XCTAssertNotEqual(session.lastProfileEnsureOutcome?.analyticsReason, "unknown")
+    }
+
+    func testTF164TripleTriggerSuccessSingleEnsurePerCycle() async {
+        UITestMockAPIProtocol.reset(
+            listProfiles: .json(
+                200,
+                object: [[
+                    "id": "listed-tf164",
+                    "user_id": "user-1",
+                    "persona_type": "adult",
+                    "sensitivity_level": "medium",
+                    "home_lat": 41.28,
+                    "home_lon": 1.976,
+                    "date_of_birth": NSNull(),
+                    "age_years": NSNull(),
+                ]]
+            )
+        )
+        var failedCount = 0
+        ProductAnalytics.testEventSink = { name, _ in
+            if name == "profile_ensure_failed" { failedCount += 1 }
+        }
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        session.displayPlaceName = "Castelldefels"
+
+        await simulateTF164ColdLaunchEnsureGraph(session: session)
+
+        XCTAssertEqual(session.profileId, "listed-tf164")
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1)
+        XCTAssertEqual(failedCount, 0)
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+        XCTAssertEqual(session.lastProfileEnsureOutcome, .ready)
+    }
+
+    func testTF164TripleTriggerHTTP500SingleEnsurePerCycle() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "boom"]))
+        var failedCount = 0
+        ProductAnalytics.testEventSink = { name, _ in
+            if name == "profile_ensure_failed" { failedCount += 1 }
+        }
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        session.displayPlaceName = "Castelldefels"
+
+        await simulateTF164ColdLaunchEnsureGraph(session: session)
+
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1)
+        XCTAssertEqual(failedCount, 1)
+        XCTAssertEqual(session.lastProfileEnsureOutcome, .failure(.server))
+        XCTAssertEqual(session.lastProfileEnsureOutcome?.diagnosticCode, "PE_HTTP_5XX")
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+    }
+
+    func testExplicitRetryAfterFailureCreatesSecondLegitimateAttempt() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "boom"]))
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+
+        await simulateTF164ColdLaunchEnsureGraph(session: session)
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1)
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+
+        UITestMockAPIProtocol.setRoute(
+            method: "GET",
+            path: "/api/profiles",
+            response: .json(
+                200,
+                object: [[
+                    "id": "retry-ok",
+                    "user_id": "user-1",
+                    "persona_type": "adult",
+                    "sensitivity_level": "medium",
+                    "home_lat": 41.28,
+                    "home_lon": 1.976,
+                    "date_of_birth": NSNull(),
+                    "age_years": NSNull(),
+                ]]
+            )
+        )
+        session.beginExplicitProfileEnsureCycle()
+        let retry = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(retry, .ready)
+        XCTAssertEqual(session.profileId, "retry-ok")
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1, "new cycle resets attempt counter")
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            2
+        )
+    }
+
+    func testNewLocationRevisionAfterTerminalCreatesNewAttempt() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "boom"]))
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        session.displayPlaceName = "Castelldefels"
+
+        _ = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1)
+
+        UITestMockAPIProtocol.setRoute(
+            method: "GET",
+            path: "/api/profiles",
+            response: .json(200, object: [])
+        )
+        // Post-terminal device move — legitimate new cycle.
+        _ = await session.applyDeviceLocation(lat: 41.39, lon: 2.17)
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            2,
+            "new location revision after terminal may ensure again"
+        )
+    }
+
+    func testSameUserTokenRefreshDoesNotDuplicateEnsure() async {
+        UITestMockAPIProtocol.reset(
+            listProfiles: .json(
+                200,
+                object: [[
+                    "id": "tok-1",
+                    "user_id": "user-1",
+                    "persona_type": "adult",
+                    "sensitivity_level": "medium",
+                    "home_lat": 41.28,
+                    "home_lon": 1.976,
+                    "date_of_birth": NSNull(),
+                    "age_years": NSNull(),
+                ]]
+            )
+        )
+        UITestMockAPIProtocol.responseDelayNanoseconds = 60_000_000
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token-old"
+        session.refreshToken = "refresh"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+
+        async let ensure: ProfileEnsureOutcome = session.ensureProfileIdIfNeeded()
+        await Task.yield()
+        session.installAuthSession(
+            SupabaseAuthSession(
+                userId: "user-1",
+                email: "a@example.com",
+                accessToken: "token-new",
+                refreshToken: "refresh-new"
+            )
+        )
+        let outcome = await ensure
+        XCTAssertEqual(outcome, .ready)
+        XCTAssertEqual(session.profileId, "tok-1")
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+    }
+
+    func testAccountSwitchDoesNotReuseStaleCycleResult() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "boom"]))
+        let session = harness.makeSession()
+        session.userId = "user-a"
+        session.accessToken = "token-a"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        _ = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(session.lastProfileEnsureOutcome, .failure(.server))
+
+        UITestMockAPIProtocol.setRoute(
+            method: "GET",
+            path: "/api/profiles",
+            response: .json(
+                200,
+                object: [[
+                    "id": "user-b-profile",
+                    "user_id": "user-b",
+                    "persona_type": "adult",
+                    "sensitivity_level": "medium",
+                    "home_lat": 41.28,
+                    "home_lon": 1.976,
+                    "date_of_birth": NSNull(),
+                    "age_years": NSNull(),
+                ]]
+            )
+        )
+        session.installAuthSession(
+            SupabaseAuthSession(
+                userId: "user-b",
+                email: "b@example.com",
+                accessToken: "token-b",
+                refreshToken: "refresh-b"
+            )
+        )
+        let outcome = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(outcome, .ready)
+        XCTAssertEqual(session.profileId, "user-b-profile")
+        XCTAssertNotEqual(session.lastProfileEnsureOutcome, .failure(.server))
+    }
+
+    func testDashboardSuccessTelemetryDoesNotClearEnsureFailureStickyUI() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "boom"]))
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        await simulateTF164ColdLaunchEnsureGraph(session: session)
+        let sticky = session.lastProfileEnsureOutcome
+        XCTAssertEqual(sticky, .failure(.server))
+        // Dashboard may still emit refresh_succeeded for air metrics — ensure sticky must remain.
+        StartupDiagnostics.track(
+            "dashboard_refresh_succeeded",
+            success: true,
+            profilePresent: false
+        )
+        XCTAssertEqual(session.lastProfileEnsureOutcome, sticky)
+        XCTAssertTrue(session.profileEnsureUserMessage != nil)
+    }
+
+    func testStaleContextUserMismatchReensures() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "a"]))
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        _ = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1)
+
+        session.userId = "user-2"
+        session.accessToken = "token-2"
+        UITestMockAPIProtocol.setRoute(
+            method: "GET",
+            path: "/api/profiles",
+            response: .json(200, object: [])
+        )
+        _ = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            2,
+            "user mismatch must open a new cycle and re-ensure"
+        )
     }
 
     func testConcurrentPrepareInSameCycleSingleFlightsEnsure() async {

--- a/mobile/ios/HiAirTests/ProfileEnsureTests.swift
+++ b/mobile/ios/HiAirTests/ProfileEnsureTests.swift
@@ -11,6 +11,7 @@ final class ProfileEnsureTests: XCTestCase {
         try await super.setUp()
         APIClient.setAuthState(nil)
         APIClient.setAuthInvalidatedHandler(nil)
+        APIInvalidURLDiagnostics.resetForTests()
         ProductAnalytics.testEventSink = nil
         harness = ProfileEnsureTestHarness()
         UITestMockAPIProtocol.isEnabled = true
@@ -26,6 +27,7 @@ final class ProfileEnsureTests: XCTestCase {
         UITestMockAPIProtocol.reset()
         APIClient.setAuthState(nil)
         APIClient.setAuthInvalidatedHandler(nil)
+        APIInvalidURLDiagnostics.resetForTests()
         try await super.tearDown()
     }
 
@@ -971,6 +973,12 @@ final class ProfileEnsureTests: XCTestCase {
     func testTF164TripleTriggerInvalidURLSingleEnsurePerCycle() async {
         UITestMockAPIProtocol.reset(listProfiles: .json(200, object: []))
         harness.apiClient.testForceListProfilesError = APIError.invalidURL
+        APIInvalidURLDiagnostics.record(
+            source: .supabaseBaseMissing,
+            hasScheme: false,
+            hasHost: false,
+            configSource: "plist"
+        )
 
         var failedEvents: [[String: String]] = []
         ProductAnalytics.testEventSink = { name, props in
@@ -1250,6 +1258,272 @@ final class ProfileEnsureTests: XCTestCase {
         )
         XCTAssertEqual(session.lastProfileEnsureOutcome, sticky)
         XCTAssertTrue(session.profileEnsureUserMessage != nil)
+    }
+
+    func testSupabaseEmptyEnvDoesNotShadowPlistURL() {
+        let resolved = SupabaseAuthService.resolveSupabaseConfiguration(
+            environment: ["SUPABASE_URL": "   ", "SUPABASE_ANON_KEY": ""],
+            infoDictionary: [
+                "SUPABASE_URL": "https://example.supabase.co",
+                "SUPABASE_ANON_KEY": "plist-anon",
+            ]
+        )
+        XCTAssertEqual(resolved.configSource, "plist")
+        XCTAssertTrue(resolved.isValid)
+        XCTAssertEqual(resolved.url?.host, "example.supabase.co")
+        XCTAssertEqual(resolved.url?.scheme, "https")
+        XCTAssertEqual(resolved.anonKey, "plist-anon")
+    }
+
+    func testSupabaseAbsentEnvUsesPlistPair() {
+        let resolved = SupabaseAuthService.resolveSupabaseConfiguration(
+            environment: [:],
+            infoDictionary: [
+                "SUPABASE_URL": "https://example.supabase.co",
+                "SUPABASE_ANON_KEY": "plist-anon",
+            ]
+        )
+        XCTAssertEqual(resolved.configSource, "plist")
+        XCTAssertTrue(resolved.isValid)
+        XCTAssertEqual(resolved.anonKey, "plist-anon")
+    }
+
+    func testSupabaseEmptyStringEnvUsesPlistPair() {
+        let resolved = SupabaseAuthService.resolveSupabaseConfiguration(
+            environment: ["SUPABASE_URL": ""],
+            infoDictionary: [
+                "SUPABASE_URL": "https://example.supabase.co",
+                "SUPABASE_ANON_KEY": "plist-anon",
+            ]
+        )
+        XCTAssertEqual(resolved.configSource, "plist")
+        XCTAssertTrue(resolved.isValid)
+    }
+
+    func testSupabaseValidEnvPairPreferredAtomically() {
+        let resolved = SupabaseAuthService.resolveSupabaseConfiguration(
+            environment: [
+                "SUPABASE_URL": "https://env.supabase.co",
+                "SUPABASE_ANON_KEY": "env-anon",
+            ],
+            infoDictionary: [
+                "SUPABASE_URL": "https://plist.supabase.co",
+                "SUPABASE_ANON_KEY": "plist-anon",
+            ]
+        )
+        XCTAssertEqual(resolved.configSource, "env")
+        XCTAssertTrue(resolved.isValid)
+        XCTAssertEqual(resolved.url?.host, "env.supabase.co")
+        XCTAssertEqual(resolved.anonKey, "env-anon", "must not mix plist anon key with env URL")
+    }
+
+    func testSupabaseMalformedEnvFailsClosedWithoutPlistFallback() {
+        let resolved = SupabaseAuthService.resolveSupabaseConfiguration(
+            environment: [
+                "SUPABASE_URL": "not-a-valid-url",
+                "SUPABASE_ANON_KEY": "env-anon",
+            ],
+            infoDictionary: [
+                "SUPABASE_URL": "https://plist.supabase.co",
+                "SUPABASE_ANON_KEY": "plist-anon",
+            ]
+        )
+        XCTAssertEqual(resolved.configSource, "env")
+        XCTAssertFalse(resolved.isValid)
+        XCTAssertNil(resolved.url)
+        XCTAssertNotEqual(resolved.url?.host, "plist.supabase.co")
+    }
+
+    func testSupabaseMalformedPlistFailsClosed() {
+        let resolved = SupabaseAuthService.resolveSupabaseConfiguration(
+            environment: [:],
+            infoDictionary: [
+                "SUPABASE_URL": "ftp://bad",
+                "SUPABASE_ANON_KEY": "plist-anon",
+            ]
+        )
+        XCTAssertEqual(resolved.configSource, "plist")
+        XCTAssertFalse(resolved.isValid)
+        XCTAssertNil(resolved.url)
+    }
+
+    func testSupabaseEnvURLWithoutKeyIsInvalidPair() {
+        let resolved = SupabaseAuthService.resolveSupabaseConfiguration(
+            environment: [
+                "SUPABASE_URL": "https://env.supabase.co",
+            ],
+            infoDictionary: [
+                "SUPABASE_URL": "https://plist.supabase.co",
+                "SUPABASE_ANON_KEY": "plist-anon",
+            ]
+        )
+        XCTAssertEqual(resolved.configSource, "env")
+        XCTAssertFalse(resolved.isValid, "env URL without env key must not borrow plist key")
+        XCTAssertEqual(resolved.anonKey, "")
+    }
+
+    func testLegacyEmptyEnvShadowingProducesInvalidURLBeforeFixSemantics() {
+        // Pre-fix: `env ?? plist ?? ""` treated empty env as present → URL(string:"") nil.
+        let env = ""
+        let plist = "https://example.supabase.co"
+        let raw = env.isEmpty ? env : (plist) // illustrate empty-first bug when env key present as ""
+        // Actual legacy used ?? so empty string env wins:
+        let legacyRaw: String = {
+            let e: String? = ""
+            let p: String? = plist
+            return e ?? p ?? ""
+        }()
+        XCTAssertEqual(legacyRaw, "")
+        XCTAssertNil(URL(string: legacyRaw))
+        _ = raw
+        let fixed = SupabaseAuthService.resolveSupabaseConfiguration(
+            environment: ["SUPABASE_URL": "", "SUPABASE_ANON_KEY": "anon"],
+            infoDictionary: [
+                "SUPABASE_URL": plist,
+                "SUPABASE_ANON_KEY": "anon",
+            ]
+        )
+        XCTAssertTrue(fixed.isValid)
+        XCTAssertEqual(fixed.configSource, "plist")
+    }
+
+    func testInvalidURLDiagnosticsNeverContainURLOrKeyMaterial() {
+        APIInvalidURLDiagnostics.resetForTests()
+        _ = SupabaseAuthService.resolveSupabaseConfiguration(
+            environment: [
+                "SUPABASE_URL": "https://secret.example/path?token=abc",
+                "SUPABASE_ANON_KEY": "",
+            ],
+            infoDictionary: [:]
+        )
+        APIInvalidURLDiagnostics.record(
+            source: .supabaseBaseMissing,
+            hasScheme: true,
+            hasHost: true,
+            configSource: "env"
+        )
+        let props = ProfileEnsureMapper.analyticsProperties(
+            for: APIError.invalidURL,
+            outcome: .failure(.transport),
+            phase: .list
+        )
+        let joined = props.map { "\($0.key)=\($0.value)" }.joined(separator: " ")
+        XCTAssertFalse(joined.contains("secret.example"))
+        XCTAssertFalse(joined.contains("token=abc"))
+        XCTAssertFalse(joined.contains("https://"))
+        XCTAssertEqual(props["error_type"], "invalid_url")
+        XCTAssertEqual(props["url_source"], "supabase_base_missing")
+        XCTAssertEqual(props["url_config_source"], "env")
+        XCTAssertEqual(props["url_has_scheme"], "1")
+        XCTAssertEqual(props["url_has_host"], "1")
+    }
+
+    func testNilSupabaseBaseThrowsInvalidURLOnAuthRefreshPath() async {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [UITestMockAPIProtocol.self]
+        let session = URLSession(configuration: config)
+        let auth = SupabaseAuthService(
+            urlSession: session,
+            supabaseURL: nil,
+            anonKey: "",
+            redirectURI: "hiair://auth/callback"
+        )
+        APIClient.setAuthState(
+            APIClient.AuthState(userId: "u1", accessToken: "a", refreshToken: "r")
+        )
+        defer { APIClient.setAuthState(nil) }
+        do {
+            _ = try await auth.refreshSession()
+            XCTFail("expected invalidURL when supabase base missing")
+        } catch let error as APIError {
+            guard case .invalidURL = error else {
+                return XCTFail("expected APIError.invalidURL, got \(error)")
+            }
+            let outcome = ProfileEnsureMapper.outcome(for: error)
+            XCTAssertEqual(outcome, .failure(.transport))
+            let props = ProfileEnsureMapper.analyticsProperties(
+                for: error,
+                outcome: outcome,
+                phase: .list
+            )
+            XCTAssertEqual(props["error_type"], "invalid_url")
+            XCTAssertEqual(props["phase"], "list")
+        } catch {
+            XCTFail("unexpected \(error)")
+        }
+    }
+
+    func testLogoutClearsEnsureCycleMemo() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "boom"]))
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        _ = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1)
+        XCTAssertEqual(session.lastProfileEnsureOutcome, .failure(.server))
+        session.logout()
+        XCTAssertNil(session.lastProfileEnsureOutcome)
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 0)
+        // New sign-in must not reuse prior terminal.
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.refreshToken = "refresh"
+        UITestMockAPIProtocol.setRoute(
+            method: "GET",
+            path: "/api/profiles",
+            response: .json(200, object: [])
+        )
+        _ = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            2
+        )
+    }
+
+    func testRapidEnsureCallsAfterTerminalDoNotCreateNewAttempts() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "boom"]))
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        await simulateTF164ColdLaunchEnsureGraph(session: session)
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1)
+        // Rapid view recreation / repeated .task — no new cycle.
+        async let a = session.ensureProfileIdIfNeeded()
+        async let b = session.ensureProfileIdIfNeeded()
+        async let c = session.ensureProfileIdIfNeeded()
+        _ = await (a, b, c)
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1)
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1
+        )
+    }
+
+    func testCancellationDoesNotStoreTerminalNetworkMemo() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(200, object: []))
+        UITestMockAPIProtocol.responseDelayNanoseconds = 200_000_000
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+        let task = Task { await session.ensureProfileIdIfNeeded() }
+        await Task.yield()
+        session.logout() // cancels in-flight + clears cycle
+        let outcome = await task.value
+        // Cancellation / abandon must not sticky-write a network transport failure.
+        XCTAssertNotEqual(outcome, .failure(.transport))
+        XCTAssertNotEqual(outcome, .failure(.offline))
+        XCTAssertNotEqual(session.lastProfileEnsureOutcome, .failure(.transport))
+        XCTAssertNotEqual(session.lastProfileEnsureOutcome, .failure(.offline))
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 0)
     }
 
     func testStaleContextUserMismatchReensures() async {

--- a/mobile/ios/HiAirTests/ProfileEnsureTests.swift
+++ b/mobile/ios/HiAirTests/ProfileEnsureTests.swift
@@ -1126,6 +1126,57 @@ final class ProfileEnsureTests: XCTestCase {
         )
     }
 
+    /// Planner refresh / Insights refresh / Dashboard recompute must call
+    /// `beginExplicitProfileEnsureCycle()` before ensure when `profileId` is empty —
+    /// otherwise a prior terminal failure is memoized and user taps cannot recover.
+    func testUserTriggeredRefreshAfterFailureCreatesSecondLegitimateAttempt() async {
+        UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "boom"]))
+        let session = harness.makeSession()
+        session.userId = "user-1"
+        session.accessToken = "token"
+        session.profileId = ""
+        session.latitude = 41.28
+        session.longitude = 1.976
+
+        _ = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(session.profileEnsureCycleAttemptCount, 1)
+
+        // Without an explicit cycle, sibling refresh would stay memoized.
+        _ = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            1,
+            "memoized terminal must not start a second network list"
+        )
+
+        UITestMockAPIProtocol.setRoute(
+            method: "GET",
+            path: "/api/profiles",
+            response: .json(
+                200,
+                object: [[
+                    "id": "user-refresh-ok",
+                    "user_id": "user-1",
+                    "persona_type": "adult",
+                    "sensitivity_level": "medium",
+                    "home_lat": 41.28,
+                    "home_lon": 1.976,
+                    "date_of_birth": NSNull(),
+                    "age_years": NSNull(),
+                ]]
+            )
+        )
+        // Same contract as Planner/Insights/Dashboard user-triggered refresh buttons.
+        session.beginExplicitProfileEnsureCycle()
+        let retry = await session.ensureProfileIdIfNeeded()
+        XCTAssertEqual(retry, .ready)
+        XCTAssertEqual(session.profileId, "user-refresh-ok")
+        XCTAssertEqual(
+            UITestMockAPIProtocol.requestCount(matching: "/api/profiles", method: "GET"),
+            2
+        )
+    }
+
     func testNewLocationRevisionAfterTerminalCreatesNewAttempt() async {
         UITestMockAPIProtocol.reset(listProfiles: .json(500, object: ["detail": "boom"]))
         let session = harness.makeSession()

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -24,6 +24,10 @@ targets:
     info:
       path: HiAir/Info.plist
       properties:
+        # Keep versions tied to build settings — hardcoded 1.0/1 in INFOPLIST_FILE would
+        # regress ASC/TestFlight build numbers if merge order ever prefers the file.
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         API_BASE_URL: $(API_BASE_URL)
         SUPABASE_URL: $(SUPABASE_URL)
         SUPABASE_ANON_KEY: $(SUPABASE_ANON_KEY)

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -9,7 +9,9 @@ targets:
     platform: iOS
     deploymentTarget: "16.0"
     sources:
-      - HiAir
+      - path: HiAir
+        excludes:
+          - Info.plist
     entitlements:
       path: HiAir/HiAir.entitlements
       properties:
@@ -17,11 +19,27 @@ targets:
           - Default
         com.apple.developer.healthkit: true
         com.apple.developer.healthkit.access: []
+    # Custom keys must be in INFOPLIST_FILE. INFOPLIST_KEY_* for non-standard keys is not
+    # embedded into the product when only GENERATE_INFOPLIST_FILE is used (TF164 invalid_url).
+    info:
+      path: HiAir/Info.plist
+      properties:
+        API_BASE_URL: $(API_BASE_URL)
+        SUPABASE_URL: $(SUPABASE_URL)
+        SUPABASE_ANON_KEY: $(SUPABASE_ANON_KEY)
+        HIAIR_AUTH_REDIRECT_URI: $(HIAIR_AUTH_REDIRECT_URI)
+        CFBundleURLTypes:
+          - CFBundleURLName: com.hiair.app.auth
+            CFBundleURLSchemes:
+              - hiair
+        LSApplicationQueriesSchemes:
+          - x-apple-health
     settings:
       base:
         CODE_SIGN_STYLE: Automatic
         DEVELOPMENT_TEAM: 43A4KW5BKB
         GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_FILE: HiAir/Info.plist
         PRODUCT_BUNDLE_IDENTIFIER: com.hiair.app
         SWIFT_VERSION: 5.0
         CURRENT_PROJECT_VERSION: 150
@@ -32,10 +50,6 @@ targets:
         INFOPLIST_KEY_UIRequiresFullScreen: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone:
           - UIInterfaceOrientationPortrait
-        INFOPLIST_KEY_CFBundleURLTypes:
-          - CFBundleURLName: com.hiair.app.auth
-            CFBundleURLSchemes:
-              - hiair
         # Export compliance: HTTPS/TLS only (exempt); skips ASC encryption questionnaire.
         INFOPLIST_KEY_ITSAppUsesNonExemptEncryption: NO
         INFOPLIST_KEY_NSLocationWhenInUseUsageDescription: >-
@@ -44,22 +58,20 @@ targets:
           HiAir reads activity, heart, sleep, breathing, temperature, and related Apple Health summaries to personalize air and heat wellness guidance. HiAir does not diagnose or treat medical conditions.
         INFOPLIST_KEY_NSHealthUpdateUsageDescription: >-
           HiAir connects to Apple Health to read wellness summaries for personal activity and recovery insights. HiAir does not write health data to Apple Health.
-        INFOPLIST_KEY_LSApplicationQueriesSchemes:
-          - x-apple-health
       configs:
         Debug:
           CODE_SIGNING_ALLOWED[sdk=iphoneos*]: NO
           CODE_SIGNING_REQUIRED[sdk=iphoneos*]: NO
-          INFOPLIST_KEY_API_BASE_URL: http://127.0.0.1:8000
           INFOPLIST_KEY_NSAppTransportSecurity_NSAllowsArbitraryLoads: YES
-          INFOPLIST_KEY_SUPABASE_URL: https://qhxesaemlhzwbunpqjoo.supabase.co
-          INFOPLIST_KEY_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw
-          INFOPLIST_KEY_HIAIR_AUTH_REDIRECT_URI: hiair://auth/callback
+          API_BASE_URL: http://127.0.0.1:8000
+          SUPABASE_URL: https://qhxesaemlhzwbunpqjoo.supabase.co
+          SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw
+          HIAIR_AUTH_REDIRECT_URI: hiair://auth/callback
         Release:
-          INFOPLIST_KEY_API_BASE_URL: https://api.hiair.io
-          INFOPLIST_KEY_SUPABASE_URL: https://qhxesaemlhzwbunpqjoo.supabase.co
-          INFOPLIST_KEY_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw
-          INFOPLIST_KEY_HIAIR_AUTH_REDIRECT_URI: hiair://auth/callback
+          API_BASE_URL: https://api.hiair.io
+          SUPABASE_URL: https://qhxesaemlhzwbunpqjoo.supabase.co
+          SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw
+          HIAIR_AUTH_REDIRECT_URI: hiair://auth/callback
   HiAirTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## Summary
- TestFlight **0.1.0 (164)** (merge `dad614d`) failed P1 on repeat cold launch: one process, three sequential `profile_ensure_failed` events — all `PE_NET_TRANSPORT` / `invalid_url` / `phase=list` at approximately **+0.90s**, **+2.48s**, and **+3.81s**. Capture complete; crash absent; UI sticky transport copy + Retry; location CTA absent. First post-overlay launch remains **INCONCLUSIVE** (syslog gap). Remaining physical matrix: **NOT RUN — STOPPED AFTER P1**.
- **Three owner paths** on cold launch: (1) `prepareSessionForDataFetch` / `profile_load_started` (Dashboard + RootTab), (2) `DailyPlannerView.task` ensure when `profileId` empty, (3) `InsightsView.task` ensure when `profileId` empty. Not the PR #39 `.profileLocationDidUpdate` path (zero typed location notifications in the TF164 capture).
- **Why in-flight-only coalescing was insufficient:** single-flight joins only while `inFlightEnsureProfile` is live. After the first terminal failure clears in-flight, sibling Tab `.task` consumers started new list attempts. PR #39 fixed typed location skip, not cycle-terminal memoization.
- **Foreground-cycle ownership:** one data-fetch / foreground cycle → one underlying ensure attempt → one terminal result memoized for that user/cycle. Sibling consumers join in-flight or reuse the terminal memo (no second analytics failure). Explicit Retry, true foreground resume (when prepare is idle), post-terminal location revision, and account switch open a new cycle. Same-user token refresh does not cancel a useful ensure. Cancellation does not sticky-write a network failure. Correctness is not based on the 8s foreground debounce. User-triggered Planner/Insights refresh and Dashboard recompute also open a new cycle when `profileId` is empty (`7cd2264`).
- **Independent `invalid_url` packaging root cause:** `listProfiles` does not throw `invalidURL` itself. Deterministic chain: **list HTTP 401 → auto-refresh → `SupabaseAuthService.request` with nil Supabase base → `APIError.invalidURL`**, while ensure phase remains `list`. Pre-fix Release products did not embed custom `SUPABASE_*` / `API_BASE_URL` via `INFOPLIST_KEY_*` + `GENERATE_INFOPLIST_FILE` alone (also missing auth URL scheme / Health query schemes from product Info.plist). Email login uses the backend session bridge, so a missing client Supabase URL still allows signed-in cold launch until refresh. Fix ships config through `HiAir/Info.plist` + `INFOPLIST_FILE` (merged with generated keys), keeps `hiair` URL scheme and `x-apple-health` queries in that plist, resolves URL + anon key **atomically**, and derives `CFBundleShortVersionString` / `CFBundleVersion` from `$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)` (`7f3cbe2`) so ASC/TF build numbers cannot regress to plist defaults.
- **Head:** `7cd2264` (review-gate fixes on top of packaging `8e28baf` + cycle `1ffd163`; intermediate packaging candidate `48fd478` is not the final head).
- **Local gates (post-review fixes):** ProfileEnsure **62 PASS**; HiAirTests **153 PASS**; ProfileBootstrap UI **6 PASS**; UI suite **11 PASS ×3**; unsigned Release Info.plist semantic OK (0.1.0/150, Supabase/API keys, `hiair` scheme, Health queries, no unresolved `$(...)`); simulator triple-trigger ×3; RU/EN UI coverage (EN bootstrap + English launch).
- **TF 164 remains `FAILED_P1_TF164`.** This PR does not reclassify TF164 and does not continue the physical matrix on build 164. A **new TestFlight** and full physical matrix are required after merge.

## Test plan
- [x] ProfileEnsureTests (≥61) + full HiAirTests (≥150)
- [x] ProfileBootstrap UI (6) + HiAirUITests 11×3
- [x] Unsigned Release product Info.plist: versions from build settings; `SUPABASE_*` / `API_BASE_URL`; `hiair` URL scheme + Health queries
- [x] Simulator physical-equivalent triple-trigger ×3 + Retry / user-refresh → second attempt
- [x] CI ios-build + Xcode Cloud Archive - iOS on latest head `7cd2264`
- [x] Security automation review on latest head `7cd2264` (Find vulnerabilities: no medium/high/critical). Bugbot did not re-run (prior usage/spend limit; check absent on new head — not a green Bugbot review).
- [ ] After merge: new TestFlight cold-launch P1, then full physical matrix (do not restore overlay 149/159→164 as the primary proof)
