### PR TITLE
test(ios): cover inactive HealthKit consent presentation

### DIFF
--- a/mobile/ios/HiAir/Screens/SettingsView.swift
+++ b/mobile/ios/HiAir/Screens/SettingsView.swift
@@ -323,6 +323,27 @@ final class SettingsViewModel: ObservableObject {
             )
             return
         }
+
+        // UITest-only inactive seed: exercise production WearableStatusPresentation with
+        // durable=true + consentActive=false without network/upload/delete. Gated by -UITesting.
+        if UITestBootstrap.seedWearableDurableInactive {
+            let durable = service.hasDurableConsent(for: expectedUserId)
+            let systemAuth = service.hasSystemAuthorization(for: expectedUserId)
+            // Keep durable marker; demote stale `.connected` presentation to OS-authorized.
+            if service.connectionState == .connected || service.connectionState == .dataUnavailable
+                || service.connectionState == .syncFailed || service.connectionState == .partial
+            {
+                service.reportConnectionState(systemAuth ? .systemAuthorized : .notConnected)
+            }
+            wearableStatus = wearableStatusLabel(
+                for: service.connectionState,
+                consentActive: false,
+                hasDurableConsent: durable,
+                hasSystemAuthorization: systemAuth
+            )
+            return
+        }
+
         do {
             let today = try await apiClient.fetchWearableToday(
                 userId: expectedUserId,

--- a/mobile/ios/HiAir/TestingSupport/UITestBootstrap.swift
+++ b/mobile/ios/HiAir/TestingSupport/UITestBootstrap.swift
@@ -30,6 +30,13 @@ enum UITestBootstrap {
         isUITesting && ProcessInfo.processInfo.environment["UITEST_DISABLE_AUTO_PROFILE"] == "1"
     }
 
+    /// Test-only: account-bound durable consent exists with server-inactive semantics.
+    /// Requires `-UITesting`. Never active in production launches.
+    static var seedWearableDurableInactive: Bool {
+        isUITesting
+            && ProcessInfo.processInfo.environment["UITEST_SEED_WEARABLE_DURABLE_INACTIVE"] == "1"
+    }
+
     static func prepareBeforeAppLaunch() {
         guard isUITesting else { return }
         if isMockAPIEnabled {
@@ -40,6 +47,30 @@ enum UITestBootstrap {
                 UITestMockAPIProtocol.reset(
                     listProfiles: .json(status, object: ["detail": "uitest status \(status)"]),
                     createProfile: .json(status, object: ["detail": "uitest status \(status)"])
+                )
+            }
+            // Inactive-consent UI seed: durable marker + inactive server payload (no upload/delete).
+            if env["UITEST_SEED_WEARABLE_DURABLE_INACTIVE"] == "1" {
+                UITestMockAPIProtocol.setRoute(
+                    method: "GET",
+                    path: "/api/v1/wearables/today",
+                    response: .json(
+                        200,
+                        object: [
+                            "consent": [
+                                "id": "uitest-inactive-consent",
+                                "userId": env["UITEST_USER_ID"] ?? "uitest-user",
+                                "platform": "ios",
+                                "source": "apple_health",
+                                "stepsEnabled": true,
+                                "heartRateEnabled": true,
+                                "restingHeartRateEnabled": true,
+                                "isActive": false,
+                            ],
+                            "dailySummary": NSNull(),
+                            "personalLoad": NSNull(),
+                        ]
+                    )
                 )
             }
         }
@@ -107,6 +138,20 @@ enum UITestBootstrap {
             if env["UITEST_SEED_STALE_CONNECTED"] == "1" {
                 hk.reportConnectionState(.connected)
             }
+        }
+
+        // Durable inactive: account-bound consent marker retained, active=false semantics.
+        // Simulates prior OS authorization via UserDefaults markers — no real HealthKit store.
+        if seedWearableDurableInactive, !session.userId.isEmpty {
+            let hk = HealthKitService.shared
+            hk.seedDurableConsentMarkersForTests(
+                userId: session.userId,
+                authorized: true,
+                consented: true
+            )
+            hk.bindAccount(userId: session.userId)
+            // Stale connected enum must not survive as account-connected UI when inactive.
+            hk.reportConnectionState(.connected)
         }
     }
 }

--- a/mobile/ios/HiAirUITests/WearableConsentUITests.swift
+++ b/mobile/ios/HiAirUITests/WearableConsentUITests.swift
@@ -64,4 +64,72 @@ final class WearableConsentUITests: XCTestCase {
             "EN authorized/inactive expected, got: \(status.label)"
         )
     }
+
+    func testWearablesShowsConsentInactiveNotConnectedRU() throws {
+        let app = UITestLaunch.launch(
+            language: "ru",
+            clearProfile: false,
+            extraEnvironment: [
+                "UITEST_PROFILE_ID": "profile-seed",
+                "UITEST_CLEAR_PROFILE": "0",
+                "UITEST_SEED_WEARABLE_DURABLE_INACTIVE": "1",
+            ]
+        )
+        app.tabBars.buttons.element(boundBy: 4).tap()
+        let status = waitForIdentifier(app, "settings.wearables.status", timeout: 10)
+        attachScreenshot(app, name: "tf171-wearables-durable-inactive-ru")
+        attachA11yDump(app, name: "tf171-wearables-durable-inactive-ru")
+
+        let label = status.label.lowercased()
+        XCTAssertTrue(status.exists)
+        XCTAssertTrue(
+            label.contains("согласие неактивно"),
+            "Expected inactive-consent copy, got: \(status.label)"
+        )
+        XCTAssertFalse(
+            label.contains("подключено") || label.contains("connected"),
+            "Inactive durable consent must not show connected: \(status.label)"
+        )
+        let connect = app.descendants(matching: .any)["settings.wearables.connect"]
+        let disconnect = app.descendants(matching: .any)["settings.wearables.disconnect"]
+        let delete = app.descendants(matching: .any)["settings.wearables.delete"]
+        XCTAssertTrue(connect.waitForExistence(timeout: 3))
+        XCTAssertTrue(disconnect.exists)
+        XCTAssertTrue(delete.exists)
+        // Disconnect must remain a distinct control from Delete (labels + identifiers).
+        XCTAssertNotEqual(disconnect.label, delete.label)
+        XCTAssertNotEqual(
+            disconnect.identifier.isEmpty ? "settings.wearables.disconnect" : disconnect.identifier,
+            delete.identifier.isEmpty ? "settings.wearables.delete" : delete.identifier
+        )
+    }
+
+    func testWearablesShowsConsentInactiveNotConnectedEN() throws {
+        let app = UITestLaunch.launch(
+            language: "en",
+            clearProfile: false,
+            extraEnvironment: [
+                "UITEST_PROFILE_ID": "profile-seed",
+                "UITEST_CLEAR_PROFILE": "0",
+                "UITEST_SEED_WEARABLE_DURABLE_INACTIVE": "1",
+            ]
+        )
+        app.tabBars.buttons.element(boundBy: 4).tap()
+        let status = waitForIdentifier(app, "settings.wearables.status", timeout: 10)
+        attachScreenshot(app, name: "tf171-wearables-durable-inactive-en")
+        attachA11yDump(app, name: "tf171-wearables-durable-inactive-en")
+
+        let label = status.label.lowercased()
+        XCTAssertTrue(
+            label.contains("consent inactive"),
+            "Expected EN inactive-consent copy, got: \(status.label)"
+        )
+        XCTAssertFalse(label.contains("connected"))
+        XCTAssertTrue(app.descendants(matching: .any)["settings.wearables.connect"].exists)
+        let disconnect = app.descendants(matching: .any)["settings.wearables.disconnect"]
+        let delete = app.descendants(matching: .any)["settings.wearables.delete"]
+        XCTAssertTrue(disconnect.exists)
+        XCTAssertTrue(delete.exists)
+        XCTAssertNotEqual(disconnect.label, delete.label)
+    }
 }


### PR DESCRIPTION
## Summary
Harness-only simulator coverage for durable-inactive Wearables presentation (TF171 sim gate).

- `UITEST_SEED_WEARABLE_DURABLE_INACTIVE` requires `-UITesting` + env (production/TestFlight inert)
- Settings refresh short-circuit exercises `WearableStatusPresentation` without real HealthKit / upload / delete
- RU/EN UITests assert `согласие неактивно` / `consent inactive` and forbid connected

## Runner stability root cause (2026-08-04)

**Cause:** host CoreSimulator contention — concurrent `xcodebuild` (other project targeting iPhone 17 Pro) caused `NSMachErrorDomain -308 (ipc/mig) server died`, which surfaced as `HiAirUITests-Runner` `signal term` / XCTH code=5 across ProfileBootstrap, TabNavigation, and WearableConsent. Not a product HealthKit crash; no EXC/Jetsam/Watchdog on HiAir.

**Workaround (proven, not committed):** run full `HiAirUITests` on an exclusive disposable iPhone 17 Pro / iOS 26.5 simulator (`simctl create` → boot → `test-without-building` by UDID; parallel workers=1). No production code change; no assertion weakening; no retries.

## Acceptance gate
| Check | Result |
|-------|--------|
| Fresh build-for-testing | SUCCEEDED |
| HiAirUITests 15×3 same binary | **15/15 ×3**, restarts=0 |
| HiAirTests | 170 PASS |
| missing/stale UI | 2 PASS |
| inactive RU/EN | 2 PASS |
| Release unsigned sim | SUCCEEDED |
| xcodegen / diff --check / secrets | clean |

Evidence (local): `.evidence/tf171-healthkit-ui-simulator/pr42-runner-stability/`

## Out of scope / unchanged
- No merge / auto-merge
- No manual TestFlight
- No backend / Supabase / Cloudflare
- Account A untouched
- Physical TF171 remains **PARTIAL**

## Test plan
- [x] WearableConsentUIState / inactive / missing-stale
- [x] HiAirTests 170
- [x] HiAirUITests 15×3 on exclusive disposable simulator
- [x] Release + xcodegen