### PR TITLE
fix(ios): Settings disconnect local-first revoke + MARKETING_VERSION 1.0

### DIFF
--- a/mobile/ios/HiAir.xcodeproj/project.pbxproj
+++ b/mobile/ios/HiAir.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		7642D4EC715458CE46C68EFB /* HealthKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BF8C26F2C4679F0DFB2F62E /* HealthKitService.swift */; };
 		77B0C3A0D969BE57865D3A5A /* UITestBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4DA4D6012AFA1C4003ECBD /* UITestBootstrap.swift */; };
 		77E0A0837CB889643F23BF59 /* RuntimePerformanceProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24B2908A1BCD2026DD269B92 /* RuntimePerformanceProbe.swift */; };
+		79DDAA28852A36E88E5C25D4 /* SettingsDisconnectLocalFirstTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67847104B8F30C42099F2318 /* SettingsDisconnectLocalFirstTests.swift */; };
 		83C91EF17F575EB1EE6DD355 /* PlaceGeocodingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFCD764FFBC4E01ED44F0E0 /* PlaceGeocodingService.swift */; };
 		841C3D6FD329442C7C057429 /* AtmosphericParticles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EADDAA7388600A083B23465 /* AtmosphericParticles.swift */; };
 		8C7E9E65CF3BC8D45B3E8274 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6B1CF7645DD4B0B92F0CA11F /* LaunchScreen.storyboard */; };
@@ -132,6 +133,7 @@
 		606F94F2339205445B9E3E37 /* HiAirColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirColors.swift; sourceTree = "<group>"; };
 		6183833DB60B26DF8F99DF12 /* HiAirLaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirLaunchView.swift; sourceTree = "<group>"; };
 		633C39532BF5572FD090BFB8 /* HealthKitTimeoutRace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitTimeoutRace.swift; sourceTree = "<group>"; };
+		67847104B8F30C42099F2318 /* SettingsDisconnectLocalFirstTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsDisconnectLocalFirstTests.swift; sourceTree = "<group>"; };
 		6B1CF7645DD4B0B92F0CA11F /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		6C80D922CB3152908E2D2892 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		6E642A50CBF2DCC12C277E05 /* HiAirAccessibilityID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiAirAccessibilityID.swift; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 				CCFBA10AF3A09D3861286628 /* InfoPlistPackagingTests.swift */,
 				2DAE1DA0A37DFC548AF3687D /* ProfileEnsureTests.swift */,
 				5AC2FF57561B3EFDA6CC22DA /* RuntimeUXRecoveryTests.swift */,
+				67847104B8F30C42099F2318 /* SettingsDisconnectLocalFirstTests.swift */,
 				E51B8943BC3F02E49B7FB4D0 /* SubscriptionServiceTests.swift */,
 				244924BEC6FD44E41B87A87B /* SupabaseAuthLogoutTransportTests.swift */,
 				85A830216F3D632CB7F632E5 /* SymptomTaxonomyDTOTests.swift */,
@@ -509,6 +512,7 @@
 				620932E297A0EFA3FE5AA010 /* InfoPlistPackagingTests.swift in Sources */,
 				630FD44D484D2D68453486A9 /* ProfileEnsureTests.swift in Sources */,
 				116362F5B5F2F56299C94173 /* RuntimeUXRecoveryTests.swift in Sources */,
+				79DDAA28852A36E88E5C25D4 /* SettingsDisconnectLocalFirstTests.swift in Sources */,
 				1E1AE86A24B33D667114E29C /* SubscriptionServiceTests.swift in Sources */,
 				DC0A682C62C0CFFCEF77D486 /* SupabaseAuthLogoutTransportTests.swift in Sources */,
 				8ED6F86166DE120D96F89B01 /* SymptomTaxonomyDTOTests.swift in Sources */,
@@ -623,7 +627,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hiair.app;
 				SDKROOT = iphoneos;
 				SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw";
@@ -705,7 +709,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hiair.app;
 				SDKROOT = iphoneos;
 				SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFoeGVzYWVtbGh6d2J1bnBxam9vIiwicm9sZSI6ImFub24iLCJpYXQiOjE3Nzk3Nzk5MzgsImV4cCI6MjA5NTM1NTkzOH0.B9TOtpcqQZS81Sx5vlRyN3nhxZTWQWzaqZ-F8RFbCZw";

--- a/mobile/ios/HiAir/Screens/SettingsView.swift
+++ b/mobile/ios/HiAir/Screens/SettingsView.swift
@@ -409,7 +409,8 @@ final class SettingsViewModel: ObservableObject {
 
     func disconnectWearables() async {
         guard !userId.isEmpty else { return }
-        _ = try? await apiClient.revokeWearableConsent(userId: userId, accessToken: accessToken)
+        // Local consent + sync cancel happen inside the service before any remote await.
+        // Do not call the API first — that would leave durable consent true during the wait.
         await HealthKitService.shared.revokeConsent(userId: userId, accessToken: accessToken)
         await refreshWearableStatus()
     }

--- a/mobile/ios/HiAirTests/InfoPlistPackagingTests.swift
+++ b/mobile/ios/HiAirTests/InfoPlistPackagingTests.swift
@@ -41,7 +41,11 @@ final class InfoPlistPackagingTests: XCTestCase {
         XCTAssertFalse(build.contains("$("), "unresolved build number: \(build)")
         XCTAssertFalse(marketing.isEmpty)
         XCTAssertFalse(build.isEmpty)
-        XCTAssertNotEqual(marketing, "1.0", "Release product must use MARKETING_VERSION (0.1.0), not plist default 1.0")
+        XCTAssertEqual(
+            marketing,
+            "1.0",
+            "Release product must expand MARKETING_VERSION (1.0) from build settings"
+        )
         XCTAssertNotEqual(build, "1", "Release product must use CURRENT_PROJECT_VERSION, not plist default 1")
 
         let supabaseURL = try XCTUnwrap(info?["SUPABASE_URL"] as? String)

--- a/mobile/ios/HiAirTests/SettingsDisconnectLocalFirstTests.swift
+++ b/mobile/ios/HiAirTests/SettingsDisconnectLocalFirstTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import HiAir
+
+/// Captures Settings-owned wearable consent DELETE calls (the premature remote path).
+private final class SettingsConsentRevokeURLProtocol: URLProtocol, @unchecked Sendable {
+    private static let lock = NSLock()
+    private static var _consentDeleteCount = 0
+    private static var _requests: [(method: String, path: String)] = []
+
+    static var consentDeleteCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _consentDeleteCount
+    }
+
+    static var requests: [(method: String, path: String)] {
+        lock.lock(); defer { lock.unlock() }
+        return _requests
+    }
+
+    static func reset() {
+        lock.lock(); defer { lock.unlock() }
+        _consentDeleteCount = 0
+        _requests = []
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let method = request.httpMethod ?? "GET"
+        let path = request.url?.path ?? ""
+        Self.lock.lock()
+        Self._requests.append((method, path))
+        if method == "DELETE", path.hasSuffix("/api/v1/wearables/consent") {
+            Self._consentDeleteCount += 1
+        }
+        Self.lock.unlock()
+
+        let body = Data(#"{"ok":true}"#.utf8)
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://settings-revoke.test/")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Regression: Settings disconnect must not remote-revoke before HealthKitService clears durable consent.
+final class SettingsDisconnectLocalFirstTests: XCTestCase {
+    override func setUp() {
+        HealthKitServiceTestLock.lock.lock()
+        SettingsConsentRevokeURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        SettingsConsentRevokeURLProtocol.reset()
+        HealthKitServiceTestLock.lock.unlock()
+    }
+
+    @MainActor
+    override func setUp() async throws {
+        let service = HealthKitService.shared
+        service.prepareForUnitTests()
+        UserDefaults.standard.removeObject(forKey: "hiair.health.authorizationCompleted.user-a")
+        UserDefaults.standard.removeObject(forKey: "hiair.health.consentPersisted.user-a")
+    }
+
+    @MainActor
+    override func tearDown() async throws {
+        HealthKitService.shared.prepareForUnitTests()
+    }
+
+    @MainActor
+    func testSettingsDisconnectDoesNotRemoteRevokeBeforeLocalClear() async {
+        let service = HealthKitService.shared
+        service.seedDurableConsentMarkersForTests(userId: "user-a")
+        service.bindAccount(userId: "user-a")
+        service.reportConnectionState(.connected)
+        XCTAssertTrue(service.hasDurableConsent(for: "user-a"))
+        XCTAssertEqual(service.connectionState, .connected)
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [SettingsConsentRevokeURLProtocol.self]
+        config.timeoutIntervalForRequest = 5
+        let api = APIClient(
+            baseURL: URL(string: "https://settings-revoke.test")!,
+            session: URLSession(configuration: config)
+        )
+        let viewModel = SettingsViewModel(apiClient: api)
+        viewModel.userId = "user-a"
+        viewModel.accessToken = "token"
+
+        var settingsDeletesSeenDuringServiceRemote = -1
+        service.testRemoteRevokeHandler = {
+            // Service remote await must run only after local clear, and Settings must not
+            // have already issued DELETE /wearables/consent (the old premature path).
+            XCTAssertFalse(
+                service.hasDurableConsent(for: "user-a"),
+                "durable consent must be cleared before any remote revoke await"
+            )
+            XCTAssertEqual(service.connectionState, .revoking)
+            settingsDeletesSeenDuringServiceRemote = SettingsConsentRevokeURLProtocol.consentDeleteCount
+            XCTAssertEqual(
+                SettingsConsentRevokeURLProtocol.consentDeleteCount,
+                0,
+                "Settings must not call revokeWearableConsent before HealthKitService local-first revoke"
+            )
+        }
+
+        await viewModel.disconnectWearables()
+
+        XCTAssertEqual(settingsDeletesSeenDuringServiceRemote, 0)
+        XCTAssertEqual(
+            SettingsConsentRevokeURLProtocol.consentDeleteCount,
+            0,
+            "Settings disconnect must not own a separate remote revoke"
+        )
+        XCTAssertFalse(service.hasDurableConsent(for: "user-a"))
+        XCTAssertNotEqual(service.connectionState, .connected)
+    }
+}

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -47,7 +47,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.hiair.app
         SWIFT_VERSION: 5.0
         CURRENT_PROJECT_VERSION: 150
-        MARKETING_VERSION: 0.1.0
+        MARKETING_VERSION: "1.0"
         INFOPLIST_KEY_CFBundleDisplayName: HiAir
         INFOPLIST_KEY_UILaunchStoryboardName: LaunchScreen
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES


### PR DESCRIPTION
## Summary
- Fixes the PR #35 release-blocker on RC `e0e96775`: `SettingsViewModel.disconnectWearables()` no longer calls `revokeWearableConsent` before `HealthKitService.revokeConsent` (local-first).
- Adds regression unit test `SettingsDisconnectLocalFirstTests` proving Settings does not issue DELETE `/api/v1/wearables/consent` before durable consent is cleared.
- Sets `MARKETING_VERSION` to `1.0` (align with ASC version 1.0) and updates packaging assertion accordingly.

## Explicitly out of scope
- Does **not** merge conflicting PR #35.
- Does **not** upload TestFlight / Submit for Review.
- Physical demote / A→B→A / IAP deferred until TF **175** and explicit owner gates.

## Test plan
- [x] `HiAirTests/SettingsDisconnectLocalFirstTests` (simulator) — PASS
- [x] `HiAirTests/InfoPlistPackagingTests` — PASS
- [ ] After merge + Xcode Cloud: confirm TF build **175** contains this SHA
- [ ] Physical demote / A→B→A / sandbox IAP only after owner binary permissions


Made with [Cursor](https://cursor.com)