### PR TITLE
fix(ios): send real StoreKit JWS for Premium verify

### DIFF
--- a/mobile/ios/HiAir/Services/SubscriptionService.swift
+++ b/mobile/ios/HiAir/Services/SubscriptionService.swift
@@ -542,54 +542,35 @@ final class SubscriptionService: ObservableObject {
 
     private func signedTransactionString(from verification: VerificationResult<Transaction>) throws -> String {
         switch verification {
-        case .verified(let transaction):
-            if let jws = appleSignedPayload(from: verification) {
-                return jws
+        case .verified:
+            // StoreKit 2 exposes the Apple-signed JWS on VerificationResult.
+            // Never fall back to a synthetic alg=none payload — production live
+            // verifiers reject it and Premium stays off after a successful purchase.
+            let jws = verification.jwsRepresentation.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !jws.isEmpty else {
+                SubscriptionDiagnostics.log("jws_representation_missing")
+                throw SubscriptionServiceError.verificationFailed
             }
-            return buildStubJws(for: transaction)
+            if jws.split(separator: ".").count != 3 {
+                SubscriptionDiagnostics.log("jws_representation_malformed")
+                throw SubscriptionServiceError.verificationFailed
+            }
+            return jws
         case .unverified(_, let error):
             throw error
         }
     }
 
-    private func appleSignedPayload(from verification: VerificationResult<Transaction>) -> String? {
-        let mirror = Mirror(reflecting: verification)
-        for child in mirror.children {
-            guard child.label == "jwsRepresentation", let jws = child.value as? String, !jws.isEmpty else {
-                continue
-            }
-            return jws
-        }
-        return nil
-    }
-
-    private func buildStubJws(for transaction: Transaction) -> String {
-        var payload: [String: Any] = [
-            "productId": transaction.productID,
-            "transactionId": String(transaction.id),
-            "originalTransactionId": String(transaction.originalID),
-            "status": "active",
-        ]
-        if let expiration = transaction.expirationDate {
-            payload["expiresDate"] = Int(expiration.timeIntervalSince1970 * 1000)
-        }
-        let header = base64URLEncode(Data("{\"alg\":\"none\"}".utf8))
-        let bodyData = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data()
-        let body = base64URLEncode(bodyData)
-        return "\(header).\(body).stub"
-    }
-
-    private func base64URLEncode(_ data: Data) -> String {
-        data.base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
-    }
-
     func userFacingMessage(for error: APIError, language: String? = nil) -> String {
         let lang = language ?? Self.uiLanguage
         switch error {
-        case .serverWithDetail, .server:
+        case .serverWithDetail(_, let detail):
+            let trimmed = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+            return HiAirL10n.t("paywall.server_error", lang: lang)
+        case .server:
             return HiAirL10n.t("paywall.server_error", lang: lang)
         case .invalidURL, .invalidResponse:
             return HiAirL10n.t("paywall.network_error", lang: lang)

--- a/mobile/ios/HiAirTests/SubscriptionServiceTests.swift
+++ b/mobile/ios/HiAirTests/SubscriptionServiceTests.swift
@@ -76,6 +76,19 @@ final class SubscriptionServiceTests: XCTestCase {
         XCTAssertEqual(StoreProductIDs.monthly, "com.hiair.premium.monthly")
         XCTAssertEqual(StoreProductIDs.yearly, "com.hiair.premium.yearly")
     }
+
+    @MainActor
+    func testUserFacingMessageSurfacesServerDetail() {
+        let service = SubscriptionService(testingFetcher: MockProductFetcher(result: .success([])))
+        let detail = "Apple transaction signature algorithm is missing or untrusted"
+        let message = service.userFacingMessage(
+            for: .serverWithDetail(statusCode: 400, detail: detail),
+            language: "en"
+        )
+        XCTAssertEqual(message, detail)
+        let generic = service.userFacingMessage(for: .server(statusCode: 503), language: "en")
+        XCTAssertTrue(generic.localizedCaseInsensitiveContains("unavailable"))
+    }
 }
 
 private final class MockProductFetcher: StoreProductFetching, @unchecked Sendable {


### PR DESCRIPTION
## Summary
- Use `VerificationResult.jwsRepresentation` instead of Mirror + `alg=none` stub when calling `/api/subscriptions/ios/verify`.
- Surface API error detail on the paywall for diagnosis.
- Physical evidence: TF **1.0 (178)** yearly Sandbox purchase activated Premium against `api.hiair.io` (`8bf921af`).

## Test plan
- [x] `HiAirTests/SubscriptionServiceTests` (incl. detail surfacing)
- [x] On-device TF 178: yearly purchase → Premium (planner)
- [ ] Monthly: same subscription group — test after yearly expires / clear history / other Sandbox account
- [x] ASC version 1.0 build attached → **178**


Made with [Cursor](https://cursor.com)