### PR TITLE
feat: connect live App Store CTA to growth funnel

### DIFF
--- a/scripts/ops/check_web_seo.py
+++ b/scripts/ops/check_web_seo.py
@@ -237,8 +237,12 @@ def main() -> int:
                 if not href.lower().startswith("mailto:hello@hiair.io"):
                     errors.append(f"{rel}: unexpected mailto {href}")
                 continue
-            if href.startswith(("https://apps.apple.com/", "https://play.google.com/")):
-                errors.append(f"{rel}: public store URL is not verified yet: {href}")
+            if href.startswith("https://play.google.com/"):
+                errors.append(f"{rel}: Google Play URL is not verified yet: {href}")
+                continue
+            if href.startswith("https://apps.apple.com/"):
+                if "id6773610034" not in href:
+                    errors.append(f"{rel}: unexpected App Store URL {href}")
                 continue
             if href.startswith("http://"):
                 errors.append(f"{rel}: insecure external link {href}")

--- a/scripts/ops/generate_web_seo_content.py
+++ b/scripts/ops/generate_web_seo_content.py
@@ -16,6 +16,23 @@ ROOT = Path(__file__).resolve().parents[2]
 WEB = ROOT / "web"
 PUBLISHED_DATE = "2026-08-25"
 CONTENT_DATE = "2026-08-26"
+APP_STORE_ID = "6773610034"
+
+
+def app_store_cta(placement: str) -> str:
+    href = (
+        f"https://apps.apple.com/us/app/hiair/id{APP_STORE_ID}"
+        "?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta"
+        f"&amp;utm_content={placement}&amp;ct=app_store_cta_{placement}"
+    )
+    return (
+        f'<a class="btn btn-primary js-app-store-cta" data-placement="{placement}" '
+        f'href="{href}">Download on the App Store</a>'
+    )
+
+
+def content_cta_placement(path: str) -> str:
+    return "guide" if path.startswith("guides") else "final"
 
 
 PAGES = [
@@ -287,6 +304,8 @@ def structured_data(page: dict[str, str]) -> str:
 
 def render(page: dict[str, str]) -> str:
     canonical = f"https://hiair.io/{page['path']}/"
+    header_cta = app_store_cta("header")
+    page_cta = app_store_cta(content_cta_placement(page["path"]))
     return f"""<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -334,7 +353,7 @@ def render(page: dict[str, str]) -> str:
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a>{header_cta}
           </nav>
         </div>
       </div>
@@ -355,8 +374,8 @@ def render(page: dict[str, str]) -> str:
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          {page_cta}
         </section>
         <p class="review-date">Last reviewed {CONTENT_DATE}. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/APP_STORE_UTM.md
+++ b/web/APP_STORE_UTM.md
@@ -1,0 +1,24 @@
+# Website → App Store UTM convention
+
+Stable query parameters for every official App Store CTA on hiair.io:
+
+| Param | Value | Notes |
+| --- | --- | --- |
+| `utm_source` | `hiair_io` | Always the marketing site |
+| `utm_medium` | `website` | Owned web |
+| `utm_campaign` | `app_store_cta` | Campaign family |
+| `utm_content` | `header` / `hero` / `final` / `guide` | Placement |
+| `ct` | `app_store_cta_{placement}` | Apple campaign token |
+
+Canonical destination:
+
+`https://apps.apple.com/us/app/hiair/id6773610034`
+
+Growth OS events:
+
+- `app_store_cta.viewed`
+- `app_store_cta.clicked`
+
+Properties: `page`, `placement`, `locale`, `campaign`. No personal or health data.
+
+Chain (within provider limits): landing page → App Store click → acquisition → activation.

--- a/web/about/index.html
+++ b/web/about/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -73,8 +73,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="final" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=final&amp;ct=app_store_cta_final">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/air-quality-sensitive/index.html
+++ b/web/air-quality-sensitive/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -77,8 +77,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="final" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=final&amp;ct=app_store_cta_final">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/contact/index.html
+++ b/web/contact/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -72,8 +72,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="final" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=final&amp;ct=app_store_cta_final">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/for-families/index.html
+++ b/web/for-families/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -78,8 +78,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="final" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=final&amp;ct=app_store_cta_final">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/for-runners/index.html
+++ b/web/for-runners/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -77,8 +77,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="final" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=final&amp;ct=app_store_cta_final">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/guides/aqi-explained/index.html
+++ b/web/guides/aqi-explained/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -84,8 +84,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="guide" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=guide&amp;ct=app_store_cta_guide">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/guides/exercise-in-heat/index.html
+++ b/web/guides/exercise-in-heat/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -83,8 +83,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="guide" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=guide&amp;ct=app_store_cta_guide">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/guides/index.html
+++ b/web/guides/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -96,8 +96,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="guide" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=guide&amp;ct=app_store_cta_guide">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/guides/when-to-open-windows/index.html
+++ b/web/guides/when-to-open-windows/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -84,8 +84,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="guide" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=guide&amp;ct=app_store_cta_guide">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>

--- a/web/index.html
+++ b/web/index.html
@@ -90,7 +90,7 @@
           <a href="/for-families/">Families</a>
           <a href="/for-runners/">Runners</a>
           <a href="/methodology/">Methodology</a>
-          <a class="btn btn-primary" href="#waitlist">Join early access</a>
+          <a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
         </nav>
           </div>
         </div>
@@ -110,11 +110,11 @@
               outdoor time with more context.
             </p>
             <div class="hero-actions">
-              <a class="btn btn-primary" href="#waitlist">Join early access</a>
+              <a class="btn btn-primary js-app-store-cta" data-placement="hero" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=hero&amp;ct=app_store_cta_hero">Download on the App Store</a>
               <a class="btn btn-secondary" href="#how-it-works">See how it works</a>
             </div>
             <p class="hero-note">
-              Wellness guidance only — not medical advice. iOS &amp; Android coming soon.
+              Wellness guidance only — not medical advice. iOS is on the App Store. Android waitlist below.
             </p>
           </div>
 
@@ -472,10 +472,10 @@
       <section class="section waitlist-section" id="waitlist" aria-labelledby="waitlist-title">
         <div class="container">
           <header class="section-header center">
-            <p class="section-eyebrow">Early access</p>
-            <h2 class="section-title" id="waitlist-title">Be first to breathe easier</h2>
+            <p class="section-eyebrow">Android / notify</p>
+            <h2 class="section-title" id="waitlist-title">Get notified for Android</h2>
             <p class="section-lead">
-              Join the waitlist for iOS and Android beta. We'll notify you when your region opens.
+              iOS is available now. Join the list if you want Android availability or a launch email for your region.
             </p>
           </header>
           <div class="lg lg--prominent lg--enter waitlist-glass">
@@ -483,6 +483,9 @@
             <div class="lg__tint" aria-hidden="true"></div>
             <div class="lg__sheen" aria-hidden="true"></div>
             <div class="lg__content">
+          <p style="margin: 0 0 16px">
+            <a class="btn btn-primary js-app-store-cta" data-placement="final" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=final&amp;ct=app_store_cta_final">Download on the App Store</a>
+          </p>
           <form class="waitlist-form" id="waitlist-form" novalidate>
             <div class="form-group">
               <label for="waitlist-email">Email address</label>
@@ -591,8 +594,8 @@
               </button>
               <div class="faq-answer" id="faq-answer-access">
                 <div class="faq-answer-inner">
-                  We are rolling out closed beta on iOS and Android. Join the waitlist above
-                  and we'll email you when your invite is ready — typically in the order sign-ups arrive.
+                  iOS is publicly listed on the App Store. Use Download on the App Store above.
+                  Android is not released yet — join the waitlist and we will email you when it opens.
                 </div>
               </div>
             </div>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -151,4 +151,73 @@
       }
     });
   }
+
+  function growthOsEventsUrl() {
+    if (window.GROWTH_OS_EVENTS_URL) {
+      return window.GROWTH_OS_EVENTS_URL;
+    }
+    if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
+      return "http://localhost:3001/api/events";
+    }
+    return "";
+  }
+
+  function growthAnonymousId() {
+    var key = "hiair_growth_anon";
+    try {
+      var existing = window.localStorage.getItem(key);
+      if (existing) {
+        return existing;
+      }
+      var created = (window.crypto && window.crypto.randomUUID && window.crypto.randomUUID()) || String(Date.now());
+      window.localStorage.setItem(key, created);
+      return created;
+    } catch (error) {
+      return "anon";
+    }
+  }
+
+  function trackGrowth(name, properties) {
+    var url = growthOsEventsUrl();
+    if (!url) {
+      return;
+    }
+    fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        productSlug: "hiair",
+        anonymousId: growthAnonymousId(),
+        name: name,
+        occurredAt: new Date().toISOString(),
+        properties: properties,
+      }),
+      keepalive: true,
+    }).catch(function () {});
+  }
+
+  var storeCtas = document.querySelectorAll(".js-app-store-cta");
+  if (storeCtas.length) {
+    var viewed = {};
+    storeCtas.forEach(function (el) {
+      var placement = el.getAttribute("data-placement") || "unknown";
+      if (!viewed[placement]) {
+        viewed[placement] = true;
+        trackGrowth("app_store_cta.viewed", {
+          page: window.location.pathname,
+          placement: placement,
+          locale: document.documentElement.lang || "en",
+          campaign: "app_store_cta",
+        });
+      }
+      el.addEventListener("click", function () {
+        trackGrowth("app_store_cta.clicked", {
+          page: window.location.pathname,
+          placement: placement,
+          locale: document.documentElement.lang || "en",
+          campaign: "app_store_cta",
+        });
+      });
+    });
+  }
 })();

--- a/web/methodology/index.html
+++ b/web/methodology/index.html
@@ -45,7 +45,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary" href="/#waitlist">Join early access</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -80,8 +80,8 @@
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
-          <p>Join the HiAir early-access list for iOS and Android availability in your region.</p>
-          <a class="btn btn-primary" href="/#waitlist">Join early access</a>
+          <p>Download HiAir on the App Store. Android is not released yet — use the waitlist on the homepage if you want a launch email.</p>
+          <a class="btn btn-primary js-app-store-cta" data-placement="final" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=final&amp;ct=app_store_cta_final">Download on the App Store</a>
         </section>
         <p class="review-date">Last reviewed 2026-08-26. Wellness guidance only — not medical advice.</p>
       </div>


### PR DESCRIPTION
## Summary
- Replaces waitlist-only homepage and hub CTAs with the live App Store listing `id6773610034`, including UTM parameters and `app_store_cta.viewed` / `app_store_cta.clicked` events.
- Keeps the Android waitlist as the secondary path. The SEO generator now emits the same App Store CTAs so Pages CI does not revert content pages.

## Test plan
- [x] `python3 scripts/ops/check_web_seo.py` PASS (13 sitemap URLs)
- [x] `python3 scripts/ops/check_web_local_routes.py` PASS (19 routes + 404)
- [x] `node --check web/js/main.js`
- [x] Generator produces no `web/` diff
- [x] App Store URL `https://apps.apple.com/us/app/hiair/id6773610034` returns HTTP 200
- [ ] GitHub `hiair-io-pages` validate job green
- [ ] After merge, production `hiair.io` HTML contains App Store CTA and waitlist


Made with [Cursor](https://cursor.com)