### PR TITLE
Send App Store CTA events to Growth OS

### DIFF
--- a/.github/workflows/hiair-io-pages.yml
+++ b/.github/workflows/hiair-io-pages.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           python3 -m py_compile scripts/ops/generate_web_seo_content.py scripts/ops/check_web_seo.py scripts/ops/check_web_local_routes.py
           node --check web/js/main.js
+          node --test web/js/growth-telemetry.test.cjs
 
   deploy:
     needs: validate
@@ -65,6 +66,23 @@ jobs:
           python3 scripts/ops/generate_web_seo_content.py
           git diff --exit-code -- web
           python3 scripts/ops/check_web_seo.py
+
+      - name: Inject Growth OS events URL
+        env:
+          GROWTH_OS_EVENTS_URL: ${{ secrets.GROWTH_OS_EVENTS_URL }}
+        run: |
+          if [ -n "${GROWTH_OS_EVENTS_URL:-}" ]; then
+            python3 - <<'PY'
+          import os
+          from pathlib import Path
+          url = os.environ["GROWTH_OS_EVENTS_URL"]
+          path = Path("web/js/main.js")
+          text = path.read_text(encoding="utf-8")
+          path.write_text(text.replace("__GROWTH_OS_EVENTS_URL__", url), encoding="utf-8")
+          PY
+          else
+            echo "GROWTH_OS_EVENTS_URL unset; production telemetry remains no-op."
+          fi
 
       - name: Deploy to Cloudflare Pages
         env:

--- a/web/js/growth-telemetry.test.cjs
+++ b/web/js/growth-telemetry.test.cjs
@@ -1,0 +1,107 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+function loadMain(windowLike) {
+  const source = fs.readFileSync(path.join(__dirname, "main.js"), "utf8");
+  const context = vm.createContext({
+    window: windowLike,
+    document: windowLike.document,
+    URLSearchParams,
+    Date,
+    fetch: windowLike.fetch,
+    console,
+  });
+  vm.runInContext(source, context);
+  return windowLike;
+}
+
+function fakeWindow(overrides) {
+  const mem = new Map();
+  const storage = {
+    getItem: (key) => mem.get(key) ?? null,
+    setItem: (key, value) => mem.set(key, String(value)),
+  };
+  const listeners = [];
+  const cta = {
+    getAttribute: (name) => (name === "data-placement" ? "hero" : null),
+    addEventListener: (type, fn) => listeners.push({ type, fn }),
+  };
+  const windowLike = {
+    GROWTH_OS_EVENTS_URL: overrides.eventsUrl,
+    location: { hostname: overrides.hostname ?? "hiair.io", pathname: "/", search: overrides.search ?? "" },
+    localStorage: storage,
+    sessionStorage: storage,
+    crypto: { randomUUID: () => "id-1" },
+    fetch: overrides.fetch,
+    matchMedia: () => ({ matches: true }),
+    document: {
+      documentElement: { lang: "en" },
+      querySelector: () => null,
+      querySelectorAll: (selector) => {
+        if (selector === ".js-app-store-cta") {
+          return [cta];
+        }
+        if (selector === ".lg--glow") {
+          return [];
+        }
+        return [];
+      },
+      getElementById: () => null,
+    },
+    listeners,
+    cta,
+  };
+  return windowLike;
+}
+
+test("CTA still binds when the Growth OS endpoint is missing", () => {
+  const calls = [];
+  const win = fakeWindow({
+    eventsUrl: "",
+    hostname: "hiair.io",
+    fetch: (...args) => {
+      calls.push(args);
+      return Promise.resolve();
+    },
+  });
+  loadMain(win);
+  assert.equal(win.listeners.length, 1);
+  win.listeners[0].fn();
+  assert.equal(calls.length, 0);
+});
+
+test("view event is not duplicated for the same placement", () => {
+  const calls = [];
+  const win = fakeWindow({
+    eventsUrl: "https://growth.example/api/v1/events",
+    fetch: (...args) => {
+      calls.push(args);
+      return Promise.resolve();
+    },
+  });
+  loadMain(win);
+  assert.equal(calls.length, 1);
+  const body = JSON.parse(calls[0][1].body);
+  assert.equal(body.name, "app_store_cta.viewed");
+  assert.equal(body.event_id, "id-1");
+});
+
+test("click emits once and CTA still works if telemetry rejects", () => {
+  const calls = [];
+  const win = fakeWindow({
+    eventsUrl: "https://growth.example/api/v1/events",
+    fetch: (...args) => {
+      calls.push(args);
+      return Promise.reject(new Error("down"));
+    },
+  });
+  loadMain(win);
+  win.listeners[0].fn();
+  win.listeners[0].fn();
+  const clicks = calls.filter((call) => JSON.parse(call[1].body).name === "app_store_cta.clicked");
+  assert.equal(clicks.length, 2);
+  assert.doesNotThrow(() => win.listeners[0].fn());
+});

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -1,6 +1,8 @@
 (function () {
   "use strict";
 
+  var GROWTH_OS_EVENTS_URL_FROM_BUILD = "__GROWTH_OS_EVENTS_URL__";
+
   const API_BASE =
     window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1"
       ? "http://127.0.0.1:8000"
@@ -156,8 +158,11 @@
     if (window.GROWTH_OS_EVENTS_URL) {
       return window.GROWTH_OS_EVENTS_URL;
     }
+    if (typeof GROWTH_OS_EVENTS_URL_FROM_BUILD === "string" && GROWTH_OS_EVENTS_URL_FROM_BUILD.indexOf("__GROWTH_OS") !== 0) {
+      return GROWTH_OS_EVENTS_URL_FROM_BUILD;
+    }
     if (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
-      return "http://localhost:3001/api/events";
+      return "http://localhost:3001/api/v1/events";
     }
     return "";
   }
@@ -177,23 +182,83 @@
     }
   }
 
+  function growthSessionId() {
+    var key = "hiair_growth_session";
+    try {
+      var existing = window.sessionStorage.getItem(key);
+      if (existing) {
+        return existing;
+      }
+      var created = (window.crypto && window.crypto.randomUUID && window.crypto.randomUUID()) || String(Date.now());
+      window.sessionStorage.setItem(key, created);
+      return created;
+    } catch (error) {
+      return "session";
+    }
+  }
+
+  function growthEventId(name, placement) {
+    var key = "hiair_growth_evt:" + name + ":" + placement;
+    try {
+      var existing = window.sessionStorage.getItem(key);
+      if (existing) {
+        return existing;
+      }
+      var created = (window.crypto && window.crypto.randomUUID && window.crypto.randomUUID()) || String(Date.now()) + placement;
+      window.sessionStorage.setItem(key, created);
+      return created;
+    } catch (error) {
+      return name + "-" + placement;
+    }
+  }
+
+  function utmFromLocation() {
+    var params = new URLSearchParams(window.location.search);
+    var properties = {};
+    ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"].forEach(function (key) {
+      var value = params.get(key);
+      if (value) {
+        properties[key] = value.slice(0, 200);
+      }
+    });
+    return properties;
+  }
+
   function trackGrowth(name, properties) {
     var url = growthOsEventsUrl();
     if (!url) {
       return;
     }
-    fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        productSlug: "hiair",
-        anonymousId: growthAnonymousId(),
-        name: name,
-        occurredAt: new Date().toISOString(),
-        properties: properties,
-      }),
-      keepalive: true,
-    }).catch(function () {});
+    var body = {
+      productSlug: "hiair",
+      surface: "website",
+      environment: "production",
+      anonymousId: growthAnonymousId(),
+      session_id: growthSessionId(),
+      event_id: growthEventId(name, properties.placement || "unknown"),
+      event_version: 1,
+      name: name,
+      occurredAt: new Date().toISOString(),
+      properties: Object.assign(
+        {
+          page: window.location.pathname,
+          locale: document.documentElement.lang || "en",
+          campaign: "app_store_cta",
+        },
+        utmFromLocation(),
+        properties
+      ),
+    };
+    try {
+      fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        keepalive: true,
+      }).catch(function () {});
+    } catch (error) {
+      return;
+    }
   }
 
   var storeCtas = document.querySelectorAll(".js-app-store-cta");


### PR DESCRIPTION
## Summary
- Inject `GROWTH_OS_EVENTS_URL` at Pages deploy time so production `hiair.io` can POST CTA view/click events to the public Growth OS ingest host.
- Keep CTA rendering and navigation independent of Growth OS availability; add client tests for missing endpoint, view dedupe, and telemetry failure.

## Test plan
- [ ] `node --check web/js/main.js` and `node --test web/js/growth-telemetry.test.cjs`
- [ ] Confirm production Pages deploy substitutes the events URL
- [ ] Open https://hiair.io/ and verify Growth OS records `app_store_cta.viewed` / `app_store_cta.clicked` without PII


Made with [Cursor](https://cursor.com)