### PR TITLE
Allow Growth OS ingest in website CSP

### DIFF
--- a/web/_headers
+++ b/web/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'self'; connect-src 'self' https://api.hiair.io; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; connect-src 'self' https://api.hiair.io https://growth-os-sable-psi.vercel.app; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests
 
 /assets/*
   Cache-Control: public, max-age=604800


### PR DESCRIPTION
## Summary
- Add `https://growth-os-sable-psi.vercel.app` to `connect-src` so App Store CTA telemetry can POST from `hiair.io`.

## Test plan
- [ ] Confirm production `Content-Security-Policy` includes the ingest host
- [ ] Open https://hiair.io/ and confirm Growth OS stores `app_store_cta.viewed` / `app_store_cta.clicked`


Made with [Cursor](https://cursor.com)