### PR TITLE
seo: search foundation for hiair.io

### DIFF
--- a/scripts/ops/check_web_seo.py
+++ b/scripts/ops/check_web_seo.py
@@ -148,8 +148,15 @@ def main() -> int:
     h1s: dict[str, str] = {}
     indexed_files: set[Path] = set()
     inbound: dict[str, int] = {}
-    if not any(path.is_file() and path.suffix == ".txt" and re.fullmatch(r"[0-9a-f]{64}", path.stem) for path in WEB.iterdir()):
-        errors.append("IndexNow key file missing from web/ (64-hex filename .txt)")
+    key_files = [
+        path
+        for path in WEB.iterdir()
+        if path.is_file() and path.suffix == ".txt" and re.fullmatch(r"[0-9a-f]{64}", path.stem)
+    ]
+    if len(key_files) != 1:
+        errors.append("IndexNow key file missing from web/ (exactly one 64-hex filename .txt)")
+    elif key_files[0].read_text(encoding="utf-8").strip() != key_files[0].stem:
+        errors.append("IndexNow key file body does not match filename stem")
 
     for url, lastmod in zip(urls, lastmods):
         if not url.startswith(f"{ORIGIN}/"):

--- a/scripts/ops/check_web_seo.py
+++ b/scripts/ops/check_web_seo.py
@@ -148,6 +148,8 @@ def main() -> int:
     h1s: dict[str, str] = {}
     indexed_files: set[Path] = set()
     inbound: dict[str, int] = {}
+    if not any(path.is_file() and path.suffix == ".txt" and re.fullmatch(r"[0-9a-f]{64}", path.stem) for path in WEB.iterdir()):
+        errors.append("IndexNow key file missing from web/ (64-hex filename .txt)")
 
     for url, lastmod in zip(urls, lastmods):
         if not url.startswith(f"{ORIGIN}/"):
@@ -209,6 +211,29 @@ def main() -> int:
         for pattern in SAFETY_CLAIM_PATTERNS:
             if re.search(pattern, text, flags=re.I):
                 errors.append(f"{rel}: unsafe or overclaiming copy matches {pattern!r}")
+        if re.search(r"<meta[^>]+name=[\"']keywords[\"']", text, flags=re.I):
+            errors.append(f"{rel}: meta keywords must not be used")
+        generated_content = str(rel) not in {"index.html", "privacy/index.html", "terms/index.html"}
+        if generated_content:
+            if "BreadcrumbList" not in text:
+                errors.append(f"{rel}: missing BreadcrumbList JSON-LD")
+            if 'aria-label="Breadcrumb"' not in text:
+                errors.append(f"{rel}: missing visible breadcrumbs")
+        if str(rel).startswith("guides/") and str(rel) != "guides/index.html" and "related-reading" not in text:
+            errors.append(f"{rel}: missing related reading")
+        if str(rel) == "for-runners/index.html" and "/guides/exercise-in-heat/" not in text:
+            errors.append(f"{rel}: runners page must link to the heat-exercise guide")
+        if str(rel) == "for-families/index.html" and "/guides/when-to-open-windows/" not in text:
+            errors.append(f"{rel}: families page must link to the ventilation guide")
+        if str(rel) == "air-quality-sensitive/index.html" and "/guides/aqi-explained/" not in text:
+            errors.append(f"{rel}: sensitive page must link to the AQI guide")
+        if str(rel) == "index.html":
+            if '"@type": "WebSite"' not in text and '"@type":"WebSite"' not in text:
+                errors.append(f"{rel}: homepage must include WebSite JSON-LD")
+            if '"@type": "FAQPage"' not in text and '"@type":"FAQPage"' not in text:
+                errors.append(f"{rel}: homepage must include FAQPage JSON-LD matching visible FAQ")
+            if 'href="/air-quality-sensitive/"' not in text:
+                errors.append(f"{rel}: homepage nav must include /air-quality-sensitive/")
 
         for key in REQUIRED_OG:
             if not parser.meta.get(key):
@@ -227,6 +252,14 @@ def main() -> int:
         if duplicate_ids:
             errors.append(f"{rel}: duplicate ids {duplicate_ids}")
 
+        if not parser.json_ld:
+            errors.append(f"{rel}: missing JSON-LD")
+
+        duplicate_ids = sorted({item for item in parser.ids if parser.ids.count(item) > 1})
+        if duplicate_ids:
+            errors.append(f"{rel}: duplicate ids {duplicate_ids}")
+
+        page_nodes: list[dict] = []
         for payload in parser.json_ld:
             try:
                 data = json.loads(payload)
@@ -234,12 +267,9 @@ def main() -> int:
                 errors.append(f"{rel}: invalid JSON-LD: {exc}")
                 continue
             nodes = walk_json(data)
+            page_nodes.extend(nodes)
             if not any(node.get("@context") == "https://schema.org" for node in nodes):
                 errors.append(f"{rel}: JSON-LD is missing schema.org context")
-            if not any(node.get("inLanguage") == "en" for node in nodes):
-                errors.append(f"{rel}: JSON-LD is missing inLanguage=en")
-            if not any(node.get("url") == url for node in nodes):
-                errors.append(f"{rel}: JSON-LD url does not match canonical")
             for node in nodes:
                 banned = BANNED_JSONLD_KEYS.intersection(node)
                 if banned:
@@ -253,6 +283,10 @@ def main() -> int:
                     and STORE.get("android", {}).get("status") != "PUBLIC_CONFIRMED"
                 ):
                     errors.append(f"{rel}: JSON-LD advertises Android before a public Play listing")
+        if page_nodes and not any(node.get("inLanguage") == "en" for node in page_nodes):
+            errors.append(f"{rel}: JSON-LD is missing inLanguage=en")
+        if page_nodes and not any(node.get("url") == url for node in page_nodes):
+            errors.append(f"{rel}: JSON-LD url does not match canonical")
 
         for href in parser.links:
             if href.startswith("mailto:"):

--- a/scripts/ops/generate_web_seo_content.py
+++ b/scripts/ops/generate_web_seo_content.py
@@ -108,6 +108,78 @@ def content_cta_placement(path: str) -> str:
     return "guide" if path.startswith("guides") else "final"
 
 
+RELATED_READING: dict[str, list[tuple[str, str]]] = {
+    "guides/aqi-explained": [
+        ("/guides/exercise-in-heat/", "Exercise in hot weather"),
+        ("/guides/when-to-open-windows/", "When to open windows"),
+        ("/air-quality-sensitive/", "Personal air-quality guidance"),
+    ],
+    "guides/exercise-in-heat": [
+        ("/guides/aqi-explained/", "What AQI means"),
+        ("/guides/when-to-open-windows/", "When to open windows"),
+        ("/for-runners/", "Heat and air for runners"),
+    ],
+    "guides/when-to-open-windows": [
+        ("/guides/aqi-explained/", "What AQI means"),
+        ("/guides/exercise-in-heat/", "Exercise in hot weather"),
+        ("/for-families/", "Family outdoor planning"),
+    ],
+}
+
+
+def breadcrumb_items(page: dict[str, str]) -> list[tuple[str, str]]:
+    items = [("Home", "https://hiair.io/")]
+    if page["path"].startswith("guides"):
+        items.append(("Guides", "https://hiair.io/guides/"))
+        if page["path"] != "guides":
+            items.append((page["heading"], f"https://hiair.io/{page['path']}/"))
+        return items
+    items.append((page["heading"], f"https://hiair.io/{page['path']}/"))
+    return items
+
+
+def breadcrumbs_html(page: dict[str, str]) -> str:
+    crumbs = breadcrumb_items(page)
+    parts: list[str] = []
+    for index, (label, href) in enumerate(crumbs):
+        if index == len(crumbs) - 1:
+            parts.append(f'<li aria-current="page">{label}</li>')
+        else:
+            parts.append(f'<li><a href="{href}">{label}</a></li>')
+    return (
+        '<nav class="breadcrumbs" aria-label="Breadcrumb"><ol>'
+        + "".join(parts)
+        + "</ol></nav>"
+    )
+
+
+def related_reading_html(page: dict[str, str]) -> str:
+    links = RELATED_READING.get(page["path"])
+    if not links:
+        return ""
+    items = "".join(f'<li><a href="{href}">{label}</a></li>' for href, label in links)
+    return (
+        '<aside class="content-section related-reading" aria-labelledby="related-reading-title">'
+        '<h2 id="related-reading-title">Related reading</h2>'
+        f"<ul>{items}</ul>"
+        "</aside>"
+    )
+
+
+def breadcrumb_jsonld(page: dict[str, str]) -> str:
+    elements = [
+        {
+            "@type": "ListItem",
+            "position": index,
+            "name": label,
+            "item": href,
+        }
+        for index, (label, href) in enumerate(breadcrumb_items(page), start=1)
+    ]
+    data = {"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": elements}
+    return json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+
+
 PAGES = [
     {
         "path": "guides",
@@ -251,6 +323,7 @@ PAGES = [
             <p>HiAir accounts are for people aged 13 and older. A family or children-outdoor profile is guidance for the adult account holder; it is not a child account and does not diagnose a child’s condition.</p>
             <h2>Useful before</h2>
             <ul><li>Playground visits and family walks</li><li>School travel and outdoor events</li><li>Sports practice and summer activities</li><li>Ventilating bedrooms and shared spaces</li></ul>
+            <p>For heat, humidity and outdoor air together, read the <a href="/guides/when-to-open-windows/">window-ventilation guide</a> before you plan indoor-outdoor swaps on hot or smoky days.</p>
           </section>
         """,
     },
@@ -271,6 +344,7 @@ PAGES = [
           <section class="content-section prose-content">
             <h2>Before you head out</h2>
             <p>Check the current local alert, the hourly trend and how you feel. Hot-weather exercise increases the risk of dehydration and heat-related illness. If you feel faint or weak, stop activity and move to a cool place.</p>
+            <p>Use the <a href="/guides/exercise-in-heat/">hot-weather exercise guide</a> for a step-by-step pre-workout check that includes AQI, not only temperature.</p>
             <p class="source-note">Reference: <a href="https://www.cdc.gov/heat-health/risk-factors/heat-and-athletes.html" rel="noopener noreferrer">CDC — Heat and Athletes</a>.</p>
           </section>
         """,
@@ -292,6 +366,7 @@ PAGES = [
           <section class="content-section prose-content">
             <h2>What HiAir does not do</h2>
             <p>HiAir does not diagnose asthma, allergies or any other condition. It does not replace local public-health alerts, a clinician or emergency services. It helps you organize environmental information for everyday planning.</p>
+            <p>Start with <a href="/guides/aqi-explained/">what AQI can and cannot tell you</a>, then use sensitivity settings in the app as a planning aid — not as a medical threshold.</p>
             <p><a class="text-link" href="/methodology/">Read how HiAir produces guidance →</a></p>
           </section>
         """,
@@ -334,12 +409,14 @@ PAGES = [
             <ul><li><strong>Calm:</strong> communicate risk without alarmist noise.</li><li><strong>Personal:</strong> use only the context a person chooses to provide.</li><li><strong>Explainable:</strong> show the reasons behind guidance.</li><li><strong>Honest:</strong> never disguise missing data as certainty.</li><li><strong>Private:</strong> minimize collection and keep control with the user.</li></ul>
             <h2>Where HiAir is available</h2>
             <p>HiAir is on the App Store for iPhone and iPad. An Android listing is not public yet. The product focuses on regions where heat and air-quality conditions frequently affect outdoor life.</p>
+            <h2>What we are building</h2>
+            <p>The website explains the same ideas the app uses: personal heat context, air quality, daily planning, and honest gaps in forecast data. Guides stay informational. The App Store listing is the product download path.</p>
           </section>
         """,
     },
     {
         "path": "contact",
-        "title": "Contact HiAir",
+        "title": "Contact HiAir — Product, Privacy, and Partnerships",
         "description": "Contact HiAir for product support, privacy questions, partnerships, media requests, or App Store download help.",
         "eyebrow": "Contact",
         "heading": "Talk with the HiAir team",
@@ -351,6 +428,10 @@ PAGES = [
             <a class="resource-card" href="mailto:hello@hiair.io?subject=HiAir%20partnership"><span class="resource-card__label">Growth</span><h2>Partnerships</h2><p>Running clubs, community organizations, publishers and workplace programs.</p><span class="text-link">Start a conversation →</span></a>
             <a class="resource-card" href="mailto:hello@hiair.io?subject=HiAir%20privacy"><span class="resource-card__label">Privacy</span><h2>Data request</h2><p>Privacy, access, correction, export or deletion questions.</p><span class="text-link">Contact the controller →</span></a>
           </div>
+          <section class="content-section prose-content">
+            <h2>How we route messages</h2>
+            <p>We read product, privacy and partnership mail at hello@hiair.io. Include your device, app version and whether the question is about the website, the iOS app, or data rights. We do not provide emergency response or clinical advice by email.</p>
+          </section>
         """,
     },
 ]
@@ -411,6 +492,7 @@ def render(page: dict[str, str]) -> str:
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{structured_data(page)}</script>
+    <script type="application/ld+json">{breadcrumb_jsonld(page)}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -426,7 +508,7 @@ def render(page: dict[str, str]) -> str:
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a>{header_cta}
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a>{header_cta}
           </nav>
         </div>
       </div>
@@ -435,6 +517,7 @@ def render(page: dict[str, str]) -> str:
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            {breadcrumbs_html(page)}
             <p class="section-eyebrow">{page['eyebrow']}</p>
             <h1>{page['heading']}</h1>
             <p class="content-hero__lead">{page['intro']}</p>
@@ -444,6 +527,7 @@ def render(page: dict[str, str]) -> str:
       </section>
       <div class="container content-main">
         {page['body']}
+        {related_reading_html(page)}
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
@@ -457,7 +541,7 @@ def render(page: dict[str, str]) -> str:
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           {footer_get_the_app()}
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/about/index.html
+++ b/web/about/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"AboutPage","name":"Weather data is abundant. Clear decisions are not.","headline":"Weather data is abundant. Clear decisions are not.","description":"HiAir turns complex heat and air-quality signals into calm, explainable guidance for everyday outdoor decisions.","url":"https://hiair.io/about/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"}}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"Weather data is abundant. Clear decisions are not.","item":"https://hiair.io/about/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li aria-current="page">Weather data is abundant. Clear decisions are not.</li></ol></nav>
             <p class="section-eyebrow">About HiAir</p>
             <h1>Weather data is abundant. Clear decisions are not.</h1>
             <p class="content-hero__lead">HiAir was created to answer the practical question behind the forecast: what does this combination of heat and air quality mean for the plan I am making today?</p>
@@ -68,7 +70,10 @@
             <ul><li><strong>Calm:</strong> communicate risk without alarmist noise.</li><li><strong>Personal:</strong> use only the context a person chooses to provide.</li><li><strong>Explainable:</strong> show the reasons behind guidance.</li><li><strong>Honest:</strong> never disguise missing data as certainty.</li><li><strong>Private:</strong> minimize collection and keep control with the user.</li></ul>
             <h2>Where HiAir is available</h2>
             <p>HiAir is on the App Store for iPhone and iPad. An Android listing is not public yet. The product focuses on regions where heat and air-quality conditions frequently affect outdoor life.</p>
+            <h2>What we are building</h2>
+            <p>The website explains the same ideas the app uses: personal heat context, air quality, daily planning, and honest gaps in forecast data. Guides stay informational. The App Store listing is the product download path.</p>
           </section>
+        
         
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
@@ -83,7 +88,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/air-quality-sensitive/index.html
+++ b/web/air-quality-sensitive/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Go beyond a generic air-quality number","headline":"Go beyond a generic air-quality number","description":"Understand combined heat and air-quality signals with sensitivity settings and clear, non-medical daily guidance.","url":"https://hiair.io/air-quality-sensitive/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"}}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"Go beyond a generic air-quality number","item":"https://hiair.io/air-quality-sensitive/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li aria-current="page">Go beyond a generic air-quality number</li></ol></nav>
             <p class="section-eyebrow">Personal environmental context</p>
             <h1>Go beyond a generic air-quality number</h1>
             <p class="content-hero__lead">HiAir combines available environmental data with the sensitivity settings you choose, while keeping guidance explainable and firmly within wellness use.</p>
@@ -71,8 +73,10 @@
           <section class="content-section prose-content">
             <h2>What HiAir does not do</h2>
             <p>HiAir does not diagnose asthma, allergies or any other condition. It does not replace local public-health alerts, a clinician or emergency services. It helps you organize environmental information for everyday planning.</p>
+            <p>Start with <a href="/guides/aqi-explained/">what AQI can and cannot tell you</a>, then use sensitivity settings in the app as a planning aid — not as a medical threshold.</p>
             <p><a class="text-link" href="/methodology/">Read how HiAir produces guidance →</a></p>
           </section>
+        
         
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
@@ -87,7 +91,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/contact/index.html
+++ b/web/contact/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Contact HiAir</title>
+    <title>Contact HiAir — Product, Privacy, and Partnerships</title>
     <meta name="description" content="Contact HiAir for product support, privacy questions, partnerships, media requests, or App Store download help." />
     <meta name="robots" content="index, follow, max-image-preview:large" />
     <link rel="canonical" href="https://hiair.io/contact/" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://hiair.io/contact/" />
     <meta property="og:site_name" content="HiAir" />
-    <meta property="og:title" content="Contact HiAir" />
+    <meta property="og:title" content="Contact HiAir — Product, Privacy, and Partnerships" />
     <meta property="og:description" content="Contact HiAir for product support, privacy questions, partnerships, media requests, or App Store download help." />
     <meta property="og:image" content="https://hiair.io/icon-1024.png" />
     <meta property="og:image:alt" content="HiAir mark" />
     <meta property="og:locale" content="en_US" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Contact HiAir" />
+    <meta name="twitter:title" content="Contact HiAir — Product, Privacy, and Partnerships" />
     <meta name="twitter:description" content="Contact HiAir for product support, privacy questions, partnerships, media requests, or App Store download help." />
     <meta name="twitter:image" content="https://hiair.io/icon-1024.png" />
     <meta name="theme-color" content="#0b1730" />
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"ContactPage","name":"Talk with the HiAir team","headline":"Talk with the HiAir team","description":"Contact HiAir for product support, privacy questions, partnerships, media requests, or App Store download help.","url":"https://hiair.io/contact/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"}}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"Talk with the HiAir team","item":"https://hiair.io/contact/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li aria-current="page">Talk with the HiAir team</li></ol></nav>
             <p class="section-eyebrow">Contact</p>
             <h1>Talk with the HiAir team</h1>
             <p class="content-hero__lead">Choose the closest topic and include enough context for us to route your message. Do not send emergency or highly sensitive medical information.</p>
@@ -68,6 +70,11 @@
             <a class="resource-card" href="mailto:hello@hiair.io?subject=HiAir%20partnership"><span class="resource-card__label">Growth</span><h2>Partnerships</h2><p>Running clubs, community organizations, publishers and workplace programs.</p><span class="text-link">Start a conversation →</span></a>
             <a class="resource-card" href="mailto:hello@hiair.io?subject=HiAir%20privacy"><span class="resource-card__label">Privacy</span><h2>Data request</h2><p>Privacy, access, correction, export or deletion questions.</p><span class="text-link">Contact the controller →</span></a>
           </div>
+          <section class="content-section prose-content">
+            <h2>How we route messages</h2>
+            <p>We read product, privacy and partnership mail at hello@hiair.io. Include your device, app version and whether the question is about the website, the iOS app, or data rights. We do not provide emergency response or clinical advice by email.</p>
+          </section>
+        
         
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
@@ -82,7 +89,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/for-families/index.html
+++ b/web/for-families/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Choose a better time for family outdoor plans","headline":"Choose a better time for family outdoor plans","description":"Plan outdoor time for your family with clearer hourly context for heat, humidity and air quality. Wellness guidance, not medical advice.","url":"https://hiair.io/for-families/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"}}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"Choose a better time for family outdoor plans","item":"https://hiair.io/for-families/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li aria-current="page">Choose a better time for family outdoor plans</li></ol></nav>
             <p class="section-eyebrow">HiAir for families</p>
             <h1>Choose a better time for family outdoor plans</h1>
             <p class="content-hero__lead">HiAir helps an adult account holder compare heat, humidity and air quality before playground time, school walks and other outdoor routines.</p>
@@ -73,7 +75,9 @@
             <p>HiAir accounts are for people aged 13 and older. A family or children-outdoor profile is guidance for the adult account holder; it is not a child account and does not diagnose a child’s condition.</p>
             <h2>Useful before</h2>
             <ul><li>Playground visits and family walks</li><li>School travel and outdoor events</li><li>Sports practice and summer activities</li><li>Ventilating bedrooms and shared spaces</li></ul>
+            <p>For heat, humidity and outdoor air together, read the <a href="/guides/when-to-open-windows/">window-ventilation guide</a> before you plan indoor-outdoor swaps on hot or smoky days.</p>
           </section>
+        
         
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
@@ -88,7 +92,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/for-runners/index.html
+++ b/web/for-runners/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"Find the better outdoor training window","headline":"Find the better outdoor training window","description":"Find a more suitable running or cycling window by comparing hourly heat, humidity and air quality with your activity.","url":"https://hiair.io/for-runners/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"}}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"Find the better outdoor training window","item":"https://hiair.io/for-runners/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li aria-current="page">Find the better outdoor training window</li></ol></nav>
             <p class="section-eyebrow">HiAir for runners</p>
             <h1>Find the better outdoor training window</h1>
             <p class="content-hero__lead">Use hourly environmental context to decide whether to train now, go later, reduce intensity or choose an indoor session.</p>
@@ -71,8 +73,10 @@
           <section class="content-section prose-content">
             <h2>Before you head out</h2>
             <p>Check the current local alert, the hourly trend and how you feel. Hot-weather exercise increases the risk of dehydration and heat-related illness. If you feel faint or weak, stop activity and move to a cool place.</p>
+            <p>Use the <a href="/guides/exercise-in-heat/">hot-weather exercise guide</a> for a step-by-step pre-workout check that includes AQI, not only temperature.</p>
             <p class="source-note">Reference: <a href="https://www.cdc.gov/heat-health/risk-factors/heat-and-athletes.html" rel="noopener noreferrer">CDC — Heat and Athletes</a>.</p>
           </section>
+        
         
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
@@ -87,7 +91,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/guides/aqi-explained/index.html
+++ b/web/guides/aqi-explained/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","name":"AQI explained: what the number can—and cannot—tell you","headline":"AQI explained: what the number can—and cannot—tell you","description":"Learn what AQI means, how common AQI categories work, and why heat, ozone, particles and personal sensitivity should be considered together.","url":"https://hiair.io/guides/aqi-explained/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"},"datePublished":"2026-08-25","dateModified":"2026-08-29"}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://hiair.io/guides/"},{"@type":"ListItem","position":3,"name":"AQI explained: what the number can—and cannot—tell you","item":"https://hiair.io/guides/aqi-explained/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li><a href="https://hiair.io/guides/">Guides</a></li><li aria-current="page">AQI explained: what the number can—and cannot—tell you</li></ol></nav>
             <p class="section-eyebrow">Air quality guide</p>
             <h1>AQI explained: what the number can—and cannot—tell you</h1>
             <p class="content-hero__lead">AQI turns measured air pollutants into a simpler public-health scale. It is useful, but it is not a personal diagnosis and scales can differ between countries.</p>
@@ -81,6 +83,7 @@
             <p class="source-note">Primary reference: <a href="https://www.airnow.gov/aqi/aqi-basics/" rel="noopener noreferrer">AirNow — AQI Basics</a>.</p>
           </section>
         
+        <aside class="content-section related-reading" aria-labelledby="related-reading-title"><h2 id="related-reading-title">Related reading</h2><ul><li><a href="/guides/exercise-in-heat/">Exercise in hot weather</a></li><li><a href="/guides/when-to-open-windows/">When to open windows</a></li><li><a href="/air-quality-sensitive/">Personal air-quality guidance</a></li></ul></aside>
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
@@ -94,7 +97,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/guides/exercise-in-heat/index.html
+++ b/web/guides/exercise-in-heat/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","name":"Plan outdoor exercise around more than temperature","headline":"Plan outdoor exercise around more than temperature","description":"A practical guide to choosing an outdoor workout window using heat, humidity, air quality, timing and your own response.","url":"https://hiair.io/guides/exercise-in-heat/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"},"datePublished":"2026-08-25","dateModified":"2026-08-29"}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://hiair.io/guides/"},{"@type":"ListItem","position":3,"name":"Plan outdoor exercise around more than temperature","item":"https://hiair.io/guides/exercise-in-heat/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li><a href="https://hiair.io/guides/">Guides</a></li><li aria-current="page">Plan outdoor exercise around more than temperature</li></ol></nav>
             <p class="section-eyebrow">Outdoor activity guide</p>
             <h1>Plan outdoor exercise around more than temperature</h1>
             <p class="content-hero__lead">A clear sky does not guarantee a comfortable workout. Heat, humidity, ozone, particles, activity intensity and personal response all belong in the decision.</p>
@@ -80,6 +82,7 @@
             <p class="source-note">Primary references: <a href="https://www.cdc.gov/heat-health/risk-factors/heat-and-athletes.html" rel="noopener noreferrer">CDC — Heat and Athletes</a> and <a href="https://www.who.int/news-room/fact-sheets/detail/climate-change-heat-and-health" rel="noopener noreferrer">WHO — Heat and health</a>.</p>
           </section>
         
+        <aside class="content-section related-reading" aria-labelledby="related-reading-title"><h2 id="related-reading-title">Related reading</h2><ul><li><a href="/guides/aqi-explained/">What AQI means</a></li><li><a href="/guides/when-to-open-windows/">When to open windows</a></li><li><a href="/for-runners/">Heat and air for runners</a></li></ul></aside>
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
@@ -93,7 +96,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/guides/index.html
+++ b/web/guides/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"CollectionPage","name":"Make clearer decisions about heat and air quality","headline":"Make clearer decisions about heat and air quality","description":"Practical, source-backed guides for understanding AQI, exercising in heat, planning family outdoor time, and deciding when to ventilate.","url":"https://hiair.io/guides/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"}}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://hiair.io/guides/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li aria-current="page">Guides</li></ol></nav>
             <p class="section-eyebrow">HiAir guides</p>
             <h1>Make clearer decisions about heat and air quality</h1>
             <p class="content-hero__lead">Short, practical explanations for the moments when a weather number is not enough. HiAir provides wellness guidance, not diagnosis or emergency advice.</p>
@@ -93,6 +95,7 @@
             </div>
           </section>
         
+        
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
@@ -106,7 +109,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/guides/when-to-open-windows/index.html
+++ b/web/guides/when-to-open-windows/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"Article","name":"When should you open the windows?","headline":"When should you open the windows?","description":"Learn how outdoor temperature, air quality, smoke and indoor comfort affect the best time to ventilate your home.","url":"https://hiair.io/guides/when-to-open-windows/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"},"datePublished":"2026-08-25","dateModified":"2026-08-29"}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"Guides","item":"https://hiair.io/guides/"},{"@type":"ListItem","position":3,"name":"When should you open the windows?","item":"https://hiair.io/guides/when-to-open-windows/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li><a href="https://hiair.io/guides/">Guides</a></li><li aria-current="page">When should you open the windows?</li></ol></nav>
             <p class="section-eyebrow">Ventilation guide</p>
             <h1>When should you open the windows?</h1>
             <p class="content-hero__lead">There is no single hour that works every day. The better decision compares outdoor air quality and temperature with conditions inside your home.</p>
@@ -81,6 +83,7 @@
             <p class="source-note">Primary references: <a href="https://www.epa.gov/indoor-air-quality-iaq/biological-contaminants-and-indoor-air-quality" rel="noopener noreferrer">US EPA — Indoor air and ventilation</a> and <a href="https://www.who.int/news-room/fact-sheets/detail/climate-change-heat-and-health" rel="noopener noreferrer">WHO — Heat and health</a>.</p>
           </section>
         
+        <aside class="content-section related-reading" aria-labelledby="related-reading-title"><h2 id="related-reading-title">Related reading</h2><ul><li><a href="/guides/aqi-explained/">What AQI means</a></li><li><a href="/guides/exercise-in-heat/">Exercise in hot weather</a></li><li><a href="/for-families/">Family outdoor planning</a></li></ul></aside>
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
@@ -94,7 +97,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,7 @@
     <title>HiAir — Heat and air guidance for everyday plans</title>
     <meta
       name="description"
-      content="HiAir combines heat, humidity, air quality and personal sensitivity into daily wellness guidance. Download HiAir on the App Store."
+      content="HiAir combines heat, humidity, air quality, and personal sensitivity into daily wellness guidance for outdoor plans. Download on the App Store. Not medical advice."
     />
     <meta name="robots" content="index, follow, max-image-preview:large" />
     <link rel="canonical" href="https://hiair.io/" />
@@ -16,7 +16,7 @@
     <meta property="og:title" content="HiAir — Heat and air guidance for everyday plans" />
     <meta
       property="og:description"
-      content="Personalized heat and air-quality guidance for families, athletes, and sensitive users. Wellness support — not medical advice."
+      content="HiAir combines heat, humidity, air quality, and personal sensitivity into daily wellness guidance for outdoor plans. Download on the App Store. Not medical advice."
     />
     <meta property="og:site_name" content="HiAir" />
     <meta property="og:locale" content="en_US" />
@@ -27,7 +27,7 @@
     <meta name="twitter:title" content="HiAir — Heat and air guidance for everyday plans" />
     <meta
       name="twitter:description"
-      content="Personalized heat and air-quality guidance for everyday outdoor plans. Wellness support — not medical advice."
+      content="HiAir combines heat, humidity, air quality, and personal sensitivity into daily wellness guidance for outdoor plans. Download on the App Store. Not medical advice."
     />
     <meta name="twitter:image" content="https://hiair.io/icon-1024.png" />
     <meta name="theme-color" content="#0b1730" />
@@ -56,6 +56,84 @@
         "downloadUrl": "https://apps.apple.com/us/app/hiair/id6773610034",
         "inLanguage": "en",
         "description": "Personal heat and air-quality wellness assistant. Not a medical device."
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "HiAir",
+        "url": "https://hiair.io/",
+        "logo": "https://hiair.io/icon-1024.png",
+        "inLanguage": "en"
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "HiAir",
+        "url": "https://hiair.io/",
+        "inLanguage": "en",
+        "publisher": { "@type": "Organization", "name": "HiAir", "url": "https://hiair.io/" }
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "url": "https://hiair.io/",
+        "inLanguage": "en",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Is HiAir a weather app?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Weather apps show conditions. HiAir interprets heat, humidity, and air quality together with your personal sensitivity to suggest better timing and practical actions for your day."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is HiAir medical advice?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. HiAir provides wellness guidance to help you plan daily activities. It is not a medical device and does not diagnose or treat conditions. For medical concerns, consult a qualified professional."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What data does HiAir use?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Environmental data (heat, humidity, air quality), optional location for local risk, profile sensitivity settings, and optional wellness logs you choose to enter."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Who is HiAir for?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Families, athletes, outdoor workers, elderly care partners, and anyone who wants clearer guidance on heat and air stress."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Where can I download HiAir?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "HiAir is available on the App Store for iPhone and iPad. Android is not publicly listed yet."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does HiAir support wearables?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "You can connect Apple Health or Health Connect after an explicit permission step. HiAir then uses aggregated activity summaries to add wellness context — not medical diagnosis."
+            }
+          }
+        ]
       }
     </script>
   </head>
@@ -91,6 +169,7 @@
           <a href="/guides/">Guides</a>
           <a href="/for-families/">Families</a>
           <a href="/for-runners/">Runners</a>
+          <a href="/air-quality-sensitive/">Sensitive</a>
           <a href="/methodology/">Methodology</a>
           <a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
         </nav>
@@ -651,6 +730,7 @@
             <h2>Explore</h2>
             <ul>
               <li><a href="/guides/">Guides</a></li>
+              <li><a href="/air-quality-sensitive/">Sensitive</a></li>
               <li><a href="/methodology/">Methodology</a></li>
               <li><a href="/about/">About HiAir</a></li>
               <li><a href="/contact/">Contact</a></li>

--- a/web/methodology/index.html
+++ b/web/methodology/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" href="/glass.css" />
     <link rel="stylesheet" href="/content.css" />
     <script type="application/ld+json">{"@context":"https://schema.org","@type":"WebPage","name":"From environmental signals to explainable guidance","headline":"From environmental signals to explainable guidance","description":"Learn how HiAir combines weather, air quality, activity context and optional sensitivity settings while handling missing data honestly.","url":"https://hiair.io/methodology/","inLanguage":"en","isPartOf":{"@type":"WebSite","name":"HiAir","url":"https://hiair.io/"},"publisher":{"@type":"Organization","name":"HiAir","url":"https://hiair.io/"}}</script>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://hiair.io/"},{"@type":"ListItem","position":2,"name":"From environmental signals to explainable guidance","item":"https://hiair.io/methodology/"}]}</script>
   </head>
   <body class="content-page">
     <a class="skip-link" href="#main">Skip to content</a>
@@ -45,7 +46,7 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" /></svg>
           </button>
           <nav id="site-nav" class="site-nav" aria-label="Primary">
-            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
+            <a href="/guides/">Guides</a><a href="/for-families/">Families</a><a href="/for-runners/">Runners</a><a href="/air-quality-sensitive/">Sensitive</a><a href="/methodology/">Methodology</a><a class="btn btn-primary js-app-store-cta" data-placement="header" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=header&amp;ct=app_store_cta_header" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a>
           </nav>
         </div>
       </div>
@@ -54,6 +55,7 @@
       <section class="content-hero">
         <div class="container content-hero__grid">
           <div>
+            <nav class="breadcrumbs" aria-label="Breadcrumb"><ol><li><a href="https://hiair.io/">Home</a></li><li aria-current="page">From environmental signals to explainable guidance</li></ol></nav>
             <p class="section-eyebrow">Methodology</p>
             <h1>From environmental signals to explainable guidance</h1>
             <p class="content-hero__lead">HiAir is designed to make everyday environmental decisions easier without pretending that a model can diagnose health or guarantee safety.</p>
@@ -77,6 +79,7 @@
             <p><a class="text-link" href="/privacy/">Read the Privacy Policy →</a></p>
           </section>
         
+        
         <section class="content-cta" aria-labelledby="content-cta-title">
           <p class="section-eyebrow">Personalize the next step</p>
           <h2 id="content-cta-title">Turn environmental data into a plan for your day</h2>
@@ -90,7 +93,7 @@
       <div class="container">
         <div class="footer-grid">
           <div class="footer-brand"><a class="footer-brand-lockup" href="/" aria-label="HiAir home"><img src="/assets/brand/mono-light.png" alt="HiAir" /></a><p>Breathe better. Live better. Personalized heat and air wellness for everyday life.</p></div>
-          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
+          <div class="footer-links"><h2>Explore</h2><ul><li><a href="/guides/">Guides</a></li><li><a href="/air-quality-sensitive/">Sensitive</a></li><li><a href="/methodology/">Methodology</a></li><li><a href="/about/">About</a></li><li><a href="/contact/">Contact</a></li></ul></div>
           <div class="footer-links"><h2>Get the app</h2><ul><li><a class="js-app-store-cta" data-placement="footer" href="https://apps.apple.com/us/app/hiair/id6773610034?utm_source=hiair_io&amp;utm_medium=website&amp;utm_campaign=app_store_cta&amp;utm_content=footer&amp;ct=app_store_cta_footer" target="_blank" rel="noopener noreferrer" aria-label="Download HiAir on the App Store">Download on the App Store</a></li><li><a href="/#download">Android notify list</a></li></ul></div>
           <div class="footer-links"><h2>Legal</h2><ul><li><a href="/privacy/">Privacy Policy</a></li><li><a href="/terms/">Terms of Service</a></li><li><a href="mailto:hello@hiair.io">hello@hiair.io</a></li></ul></div>
         </div>


### PR DESCRIPTION
## Summary
- Adds unique crawlable breadcrumbs, related-reading, and homepage WebSite/FAQ/Organization JSON-LD without `<meta name="keywords">`.
- Tightens `check_web_seo.py` so every indexable URL still has a unique title, description, H1, self-canonical, and IndexNow key file.
- Does **not** publish a Spanish URL cluster; GSC still has zero query rows.

## Test plan
- [ ] `python3 scripts/ops/check_web_seo.py` passes locally (13 unique sitemap titles)
- [ ] Pages workflow validate job runs on this PR
- [ ] After merge, production `/sitemap.xml` and `/robots.txt` still declare `https://hiair.io/sitemap.xml`
- [ ] Spot-check home, one guide, and `/for-runners/` for breadcrumbs / related links
- [ ] Confirm no medical overclaims and no Android Play URL


Made with [Cursor](https://cursor.com)