### PR TITLE
ci: stop accidental Xcode Cloud App Store uploads

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -1,6 +1,7 @@
 name: iOS CI
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - "mobile/ios/**"

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Verify Xcode Cloud iOS source gate
+        working-directory: ${{ github.workspace }}
+        run: bash mobile/ios/ci_scripts/test_ios_app_source_gate.sh
+
       - name: Install XcodeGen
         run: brew install xcodegen
 

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -25,6 +25,10 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: bash mobile/ios/ci_scripts/test_ios_app_source_gate.sh
 
+      - name: Verify Xcode Cloud release-intent and marketing-version gates
+        working-directory: ${{ github.workspace }}
+        run: bash mobile/ios/ci_scripts/test_ios_release_gates.sh
+
       - name: Install XcodeGen
         run: brew install xcodegen
 

--- a/docs/ios/XCODE_CLOUD_RELEASE_POLICY.md
+++ b/docs/ios/XCODE_CLOUD_RELEASE_POLICY.md
@@ -53,7 +53,7 @@ Until the ASC UI is split, the **same** Xcode Cloud workflow may still *start* o
    - Release workflow: Archive + TestFlight Internal, **Manual** and/or tags `ios-*`, **no** production App Store auto-submit.
 4. Do not attach a GitHub required status to the Archive workflow.
 
-Apple-supported start conditions: Branch Changes, Pull Request Changes, Tag Changes, Schedule, Manual. Path filtering exists only as Files and Folders in the workflow UI, not as a GitHub Actions `paths:` block. `[ci skip]` in the latest commit message skips the build entirely.
+Apple-supported start conditions: Branch Changes, Pull Request Changes, Tag Changes, Schedule, Manual. Path filtering exists only as Files and Folders in the workflow UI, not as a GitHub Actions `paths:` block. Apple `[ci skip]` in the latest commit message skips Xcode Cloud. GitHub also skips Actions when the message contains `[ci skip]`, so do not use that token on PRs that still need `ios-ci.yml`.
 
 ## Version source of truth
 

--- a/docs/ios/XCODE_CLOUD_RELEASE_POLICY.md
+++ b/docs/ios/XCODE_CLOUD_RELEASE_POLICY.md
@@ -1,0 +1,91 @@
+# Xcode Cloud release policy
+
+**App:** HiAir (`com.hiair.app`, Apple ID `6773610034`)  
+**Last updated:** 2026-08-29
+
+This document is the repository policy after the 2026-08-29 incident: web/SEO/docs commits triggered Xcode Cloud **Archive** and App Store Connect delivery of a binary still stamped `CFBundleShortVersionString = 1.0.1` while the live store version is **1.1**.
+
+Apple rejected those deliveries (`ITMS-90478`, `ITMS-90186`, `ITMS-90062`). The SEO diffs were not the version error. The architecture error was coupling ordinary git events to App Store distribution.
+
+Git cannot edit App Store Connect workflow start conditions. This repo adds a fail-closed `ci_post_clone.sh` gate. An owner still must align the ASC workflow UI with the design below.
+
+## Workflow A — iOS validation (no App Store upload)
+
+| Item | Value |
+|------|--------|
+| Mechanism | GitHub Actions `.github/workflows/ios-ci.yml` |
+| Purpose | Compile Debug + Release simulator, run `HiAirTests` |
+| Triggers | `push` / `pull_request` **path-filtered** to `mobile/ios/**` |
+| Distribution | None (`CODE_SIGNING_ALLOWED=NO`) |
+
+This is the allowed automatic check for iOS source changes, including PRs.
+
+## Workflow B — iOS release (Archive + App Store Connect)
+
+| Item | Value |
+|------|--------|
+| Current ASC name | `HiAir TestFlight` (configured in App Store Connect / Xcode, not in git) |
+| Purpose | Archive, sign, upload to App Store Connect |
+| Allowed git starts (enforced in `ci_post_clone.sh`) | Manual start, `manual_rebuild`, Git tag `ios-*` / `v*` / `release-*`, branch `release/*` |
+| Forbidden automatic starts | Any branch push, PR open/update, schedule, web/docs/SEO, `ci_scripts`-only |
+
+Until the ASC UI is split, the **same** Xcode Cloud workflow may still *start* on web commits. The post-clone script then **exits 1** so Archive does not produce an upload. A red Xcode Cloud check on a web PR is expected and is **not** a GitHub required check.
+
+### Owner action in App Store Connect (cannot be done from git)
+
+1. **Files and Folders** custom condition: start only if `mobile/ios` changes (optional; the script already refuses web-only).
+2. Restrict Branch Changes: do **not** use Any Branch for Archive.
+3. Preferred split:
+   - Validation workflow: Build + Test only, PRs / iOS branches, **no Archive**.
+   - Release workflow: Archive + TestFlight Internal, **Manual** and/or tags `ios-*`, **no** production App Store auto-submit.
+4. Do not attach a GitHub required status to the Archive workflow.
+
+Apple-supported start conditions: Branch Changes, Pull Request Changes, Tag Changes, Schedule, Manual. Path filtering exists only as Files and Folders in the workflow UI, not as a GitHub Actions `paths:` block. `[ci skip]` in the latest commit message skips the build entirely.
+
+## Version source of truth
+
+| Key | Location | Value on `main` (2026-08-29) |
+|-----|----------|------------------------------|
+| `MARKETING_VERSION` | `mobile/ios/project.yml` → XcodeGen → `HiAir.xcodeproj` | `1.0.1` (**stale**) |
+| `CFBundleShortVersionString` | `HiAir/Info.plist` = `$(MARKETING_VERSION)` | expands to `1.0.1` |
+| `CURRENT_PROJECT_VERSION` | `project.yml` | `215` |
+| `CFBundleVersion` | `Info.plist` = `$(CURRENT_PROJECT_VERSION)` | expands to `215` unless Xcode Cloud overrides with `CI_BUILD_NUMBER` |
+| Live App Store | iTunes lookup `id=6773610034` | **`1.1`** |
+
+Build 267 reported `1.0.1` because the committed marketing version is `1.0.1`. App Store Connect build numbers (259–267) are not the repo `215`; raising `CFBundleVersion` alone does **not** fix `ITMS-90478`.
+
+Do **not** bump `MARKETING_VERSION` on `main` merely so accidental uploads succeed. Fail-closed rejection is safer than a successful unintended `1.1.1` binary.
+
+## Next intentional marketing version
+
+Must be **greater than 1.1**. Project roadmap next train is **1.2** (`docs/roadmap/HIAIR_1_2_BEST_TIME_ACTIVITY_PLANNER.md`). Do not upload a binary until an owner intends that iOS release, with `MARKETING_VERSION` already set on a `release/*` branch or `ios-*` tag.
+
+`ci_post_clone.sh` refuses Archive while marketing version is `1.0`, `1.0.*`, `1.1`, or `1.1.0`.
+
+## Build-number policy
+
+`CFBundleVersion` / `CURRENT_PROJECT_VERSION` must increase monotonically for each uploaded binary. That is necessary but **not sufficient**. The 2026-08-29 failures were marketing-version / closed pre-release train, not a duplicate build number.
+
+## What may trigger distribution
+
+| Change | GitHub iOS CI | Xcode Cloud Archive → ASC |
+|--------|---------------|---------------------------|
+| `web/`, docs, SEO, IndexNow | No (path filter) | Must not upload (script skip) |
+| `mobile/ios/ci_scripts` only | Yes (paths include `mobile/ios/**`) | Must not upload |
+| iOS app source on feature/`main` | Yes | Must not upload automatically |
+| Explicit release (manual / `release/*` / `ios-*` tag) **and** marketing version > 1.1 | As applicable | Allowed |
+
+## GitHub required checks
+
+`main` has **no** classic branch protection and **no** rulesets (`GET .../branches/main/protection` → 404, `rulesets` → `[]`).
+
+**`XCODE_CLOUD_REQUIRED = NO`.**
+
+Failed App Store delivery must not block web merges. Do not admin-bypass. Do not make Archive a required check.
+
+## Related files
+
+- `mobile/ios/ci_scripts/ci_post_clone.sh`
+- `mobile/ios/ci_scripts/ios_app_source_gate.sh`
+- `docs/release/XCODE_CLOUD_SETUP.md`
+- `.github/workflows/ios-ci.yml`

--- a/docs/ios/XCODE_CLOUD_RELEASE_POLICY.md
+++ b/docs/ios/XCODE_CLOUD_RELEASE_POLICY.md
@@ -26,8 +26,21 @@ This is the allowed automatic check for iOS source changes, including PRs.
 |------|--------|
 | Current ASC name | `HiAir TestFlight` (configured in App Store Connect / Xcode, not in git) |
 | Purpose | Archive, sign, upload to App Store Connect |
-| Allowed git starts (enforced in `ci_post_clone.sh`) | Manual start, `manual_rebuild`, Git tag `ios-*` / `v*` / `release-*`, branch `release/*` |
+| Allowed git starts (enforced in `ci_post_clone.sh`) | See **ARCHIVE_ALLOWED** below |
 | Forbidden automatic starts | Any branch push, PR open/update, schedule, web/docs/SEO, `ci_scripts`-only |
+
+### ARCHIVE_ALLOWED (exact rule in `ci_post_clone.sh`)
+
+Archive/App Store delivery is allowed only when **all** of these are true:
+
+1. **Release intent** (`explicit_ios_release_start`):
+   - `CI_START_CONDITION` is `manual` or `manual_rebuild`, **or**
+   - `CI_TAG` matches `ios-*`, `v[0-9]*`, or `release-*`, **or**
+   - `CI_BRANCH` matches `release/*`
+2. **iOS app source** changed in the commit/PR diff (`ios_app_source_gate.sh`). `web/`, `docs/`, and `mobile/ios/ci_scripts` alone do **not** count.
+3. **Marketing version > live 1.1** (`stale_marketing_version` is false). Source: `MARKETING_VERSION` in `mobile/ios/project.yml` (that string is `CFBundleShortVersionString`). Rejected: `1.0`, `1.0.*`, `1.1`, `1.1.0`. `CFBundleVersion` / `CURRENT_PROJECT_VERSION` is not consulted.
+
+Otherwise `ci_post_clone.sh` exits 1 and Xcode Cloud does not Archive.
 
 Until the ASC UI is split, the **same** Xcode Cloud workflow may still *start* on web commits. The post-clone script then **exits 1** so Archive does not produce an upload. A red Xcode Cloud check on a web PR is expected and is **not** a GitHub required check.
 
@@ -79,7 +92,7 @@ Must be **greater than 1.1**. Project roadmap next train is **1.2** (`docs/roadm
 
 `main` has **no** classic branch protection and **no** rulesets (`GET .../branches/main/protection` → 404, `rulesets` → `[]`).
 
-**`XCODE_CLOUD_REQUIRED = NO`.**
+**`XCODE_CLOUD_REQUIRED_FOR_MAIN = NO`.** Required status checks: **none**. Rulesets: **none**.
 
 Failed App Store delivery must not block web merges. Do not admin-bypass. Do not make Archive a required check.
 

--- a/docs/release/TESTFLIGHT_CHECKLIST.md
+++ b/docs/release/TESTFLIGHT_CHECKLIST.md
@@ -21,7 +21,7 @@
 
 ### A) Xcode Cloud (recommended)
 
-See `docs/release/XCODE_CLOUD_SETUP.md` — push to `main`, workflow **HiAir TestFlight**.
+See `docs/ios/XCODE_CLOUD_RELEASE_POLICY.md`. Do **not** treat a push to `main` as an App Store upload. Workflow **HiAir TestFlight** is release-only.
 
 ### B) Local (Xcode 26+)
 

--- a/docs/release/XCODE_CLOUD_SETUP.md
+++ b/docs/release/XCODE_CLOUD_SETUP.md
@@ -13,7 +13,11 @@
 | Bundle ID | `com.hiair.app` |
 | Team ID | `43A4KW5BKB` |
 
-Скрипты CI: `mobile/ios/ci_scripts/ci_post_clone.sh` (XcodeGen + SwiftPM).
+Скрипты CI: `mobile/ios/ci_scripts/ci_post_clone.sh` (release gate + XcodeGen + SwiftPM).
+
+**Incident (2026-08-29):** the live ASC workflow also started Archive on feature branches and PRs (`seo/search-foundation`, `feat/web-live-store-qr`, `docs/live-store-audit-followup`, `main`) and delivered binaries with `CFBundleShortVersionString = 1.0.1` against live store **1.1**. Policy: `docs/ios/XCODE_CLOUD_RELEASE_POLICY.md`. `ci_post_clone.sh` now refuses automatic Archive unless the start is Manual / `release/*` / tag `ios-*` (and marketing version > 1.1).
+
+**Do not push to `main` expecting an App Store upload.** Web/SEO commits must never distribute.
 
 ## 1. Подключить репозиторий (один раз)
 
@@ -33,7 +37,7 @@
 | Project/Workspace | `mobile/ios/HiAir.xcodeproj` |
 | Scheme | `HiAir` |
 | Platform | iOS |
-| Start condition | Branch Changes → **`main`** (не feature-ветки со старым `project.pbxproj`) |
+| Start condition (intended) | **Manual**, Tag `ios-*`, or Branch `release/*` — **not** Any Branch, **not** every PR |
 
 **Actions (порядок):**
 
@@ -52,10 +56,11 @@
 
 ## 4. Запуск
 
-- Push в `main` с изменениями под `mobile/ios/**`, или  
-- Xcode Cloud → workflow → **Start Build**
+Ordinary iOS compile/test: GitHub Actions **iOS CI** (path-filtered). It does not upload.
 
-После успешного Archive сборка появится в **TestFlight** (обработка Apple 5–30 мин).
+App Store Connect upload: Xcode Cloud → **Start Build** (Manual), or an `ios-*` tag / `release/*` branch **after** `MARKETING_VERSION` is greater than live **1.1**. See `docs/ios/XCODE_CLOUD_RELEASE_POLICY.md`.
+
+После успешного Archive сборка появится в **TestFlight** (обработка Apple 5–30 мин). Do not auto-submit to the production App Store.
 
 ## 5. Локальная загрузка (если есть Xcode 26)
 

--- a/mobile/ios/HiAirTests/InfoPlistPackagingTests.swift
+++ b/mobile/ios/HiAirTests/InfoPlistPackagingTests.swift
@@ -41,12 +41,18 @@ final class InfoPlistPackagingTests: XCTestCase {
         XCTAssertFalse(build.contains("$("), "unresolved build number: \(build)")
         XCTAssertFalse(marketing.isEmpty)
         XCTAssertFalse(build.isEmpty)
+        let expectedMarketing = try Self.marketingVersionFromProjectYml()
         XCTAssertEqual(
             marketing,
-            "1.0",
-            "Release product must expand MARKETING_VERSION (1.0) from build settings"
+            expectedMarketing,
+            "Release product must expand MARKETING_VERSION from project.yml (CFBundleShortVersionString source of truth)"
         )
         XCTAssertNotEqual(build, "1", "Release product must use CURRENT_PROJECT_VERSION, not plist default 1")
+        XCTAssertNotEqual(
+            build,
+            marketing,
+            "CFBundleVersion is independent of CFBundleShortVersionString; a higher build must not imply a new marketing train"
+        )
 
         let supabaseURL = try XCTUnwrap(info?["SUPABASE_URL"] as? String)
         let apiBase = try XCTUnwrap(info?["API_BASE_URL"] as? String)
@@ -66,6 +72,25 @@ final class InfoPlistPackagingTests: XCTestCase {
         XCTAssertNotNil(info?["NSHealthShareUsageDescription"] as? String)
         XCTAssertNotNil(info?["NSHealthUpdateUsageDescription"] as? String)
         XCTAssertNotNil(info?["NSLocationWhenInUseUsageDescription"] as? String)
+    }
+
+    private static func marketingVersionFromProjectYml() throws -> String {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<8 {
+            url.deleteLastPathComponent()
+            let candidate = url.appendingPathComponent("project.yml")
+            guard FileManager.default.fileExists(atPath: candidate.path) else { continue }
+            let text = try String(contentsOf: candidate, encoding: .utf8)
+            let pattern = #"MARKETING_VERSION:\s*"([^"]+)""#
+            let regex = try NSRegularExpression(pattern: pattern)
+            let range = NSRange(text.startIndex..<text.endIndex, in: text)
+            guard let match = regex.firstMatch(in: text, range: range),
+                  let valueRange = Range(match.range(at: 1), in: text) else {
+                throw XCTSkip("MARKETING_VERSION not found in project.yml")
+            }
+            return String(text[valueRange])
+        }
+        throw XCTSkip("project.yml not found relative to test source")
     }
 
     private static func locateSourceInfoPlist() throws -> URL {

--- a/mobile/ios/ci_scripts/ci_post_clone.sh
+++ b/mobile/ios/ci_scripts/ci_post_clone.sh
@@ -2,6 +2,7 @@
 # Xcode Cloud: refuse Archive / App Store upload unless this is an explicit
 # iOS release AND iOS app source changed AND marketing version is > live 1.1.
 # Then ensure HiAir.xcodeproj includes all Swift sources and resolve SPM.
+# GitHub Actions iOS CI (simulator, no signing) is the validation path.
 set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)

--- a/mobile/ios/ci_scripts/ci_post_clone.sh
+++ b/mobile/ios/ci_scripts/ci_post_clone.sh
@@ -6,6 +6,8 @@ set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 GATE="$SCRIPT_DIR/ios_app_source_gate.sh"
+# shellcheck source=ios_release_gates.sh
+. "$SCRIPT_DIR/ios_release_gates.sh"
 REPO="${CI_PRIMARY_REPOSITORY_PATH:-}"
 if [ -z "$REPO" ]; then
   REPO=$(CDPATH= cd -- "$SCRIPT_DIR/../../.." && pwd)
@@ -14,27 +16,6 @@ fi
 # Live App Store CFBundleShortVersionString confirmed via iTunes lookup id=6773610034.
 # 1.0.1 and 1.1 must never be uploaded again. Raising CFBundleVersion alone does not
 # satisfy ITMS-90478 / ITMS-90186 / ITMS-90062.
-stale_marketing_version() {
-  case "$1" in
-    1.0|1.0.*|1.1|1.1.0) return 0 ;;
-  esac
-  return 1
-}
-
-explicit_ios_release_start() {
-  case "${CI_START_CONDITION:-}" in
-    manual|manual_rebuild) return 0 ;;
-  esac
-  if [ -n "${CI_TAG:-}" ]; then
-    case "$CI_TAG" in
-      ios-*|v[0-9]*|release-*) return 0 ;;
-    esac
-  fi
-  case "${CI_BRANCH:-}" in
-    release/*) return 0 ;;
-  esac
-  return 1
-}
 
 collect_changed_paths() {
   cd "$REPO"

--- a/mobile/ios/ci_scripts/ci_post_clone.sh
+++ b/mobile/ios/ci_scripts/ci_post_clone.sh
@@ -1,8 +1,102 @@
 #!/bin/sh
-# Xcode Cloud: ensure HiAir.xcodeproj includes all Swift sources, then resolve SPM.
+# Xcode Cloud: refuse Archive / App Store upload unless this is an explicit
+# iOS release AND iOS app source changed AND marketing version is > live 1.1.
+# Then ensure HiAir.xcodeproj includes all Swift sources and resolve SPM.
 set -eu
 
-IOS_DIR="${CI_PRIMARY_REPOSITORY_PATH}/mobile/ios"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+GATE="$SCRIPT_DIR/ios_app_source_gate.sh"
+REPO="${CI_PRIMARY_REPOSITORY_PATH:-}"
+if [ -z "$REPO" ]; then
+  REPO=$(CDPATH= cd -- "$SCRIPT_DIR/../../.." && pwd)
+fi
+
+# Live App Store CFBundleShortVersionString confirmed via iTunes lookup id=6773610034.
+# 1.0.1 and 1.1 must never be uploaded again. Raising CFBundleVersion alone does not
+# satisfy ITMS-90478 / ITMS-90186 / ITMS-90062.
+stale_marketing_version() {
+  case "$1" in
+    1.0|1.0.*|1.1|1.1.0) return 0 ;;
+  esac
+  return 1
+}
+
+explicit_ios_release_start() {
+  case "${CI_START_CONDITION:-}" in
+    manual|manual_rebuild) return 0 ;;
+  esac
+  if [ -n "${CI_TAG:-}" ]; then
+    case "$CI_TAG" in
+      ios-*|v[0-9]*|release-*) return 0 ;;
+    esac
+  fi
+  case "${CI_BRANCH:-}" in
+    release/*) return 0 ;;
+  esac
+  return 1
+}
+
+collect_changed_paths() {
+  cd "$REPO"
+  if [ -n "${CI_PULL_REQUEST_TARGET_COMMIT:-}" ] && [ -n "${CI_COMMIT:-}" ]; then
+    git fetch --depth=50 origin "${CI_PULL_REQUEST_TARGET_COMMIT}" >/dev/null 2>&1 || true
+    if git cat-file -e "${CI_PULL_REQUEST_TARGET_COMMIT}^{commit}" 2>/dev/null; then
+      git diff --name-only "${CI_PULL_REQUEST_TARGET_COMMIT}" "${CI_COMMIT}"
+      return
+    fi
+  fi
+  if ! git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+    git fetch --deepen=20 >/dev/null 2>&1 || true
+  fi
+  if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
+    git diff --name-only HEAD^1 HEAD
+  elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+    git diff --name-only HEAD^ HEAD
+  else
+    echo "XCODE_CLOUD_SKIP: cannot determine changed paths (shallow clone without parent)."
+    return 1
+  fi
+}
+
+echo "==> Xcode Cloud post-clone gate"
+echo "    CI_WORKFLOW=${CI_WORKFLOW:-unset}"
+echo "    CI_BRANCH=${CI_BRANCH:-unset}"
+echo "    CI_TAG=${CI_TAG:-unset}"
+echo "    CI_START_CONDITION=${CI_START_CONDITION:-unset}"
+echo "    CI_XCODEBUILD_ACTION=${CI_XCODEBUILD_ACTION:-unset}"
+echo "    CI_PULL_REQUEST_NUMBER=${CI_PULL_REQUEST_NUMBER:-unset}"
+
+if ! explicit_ios_release_start; then
+  echo "XCODE_CLOUD_SKIP: automatic Archive is not an iOS release start."
+  echo "Allowed starts: Manual, tag ios-* / v* / release-*, or branch release/*."
+  echo "Web/docs/SEO pushes must not upload to App Store Connect."
+  echo "Use GitHub Actions workflow ios-ci.yml for compile/test validation."
+  exit 1
+fi
+
+CHANGED=$(collect_changed_paths) || {
+  echo "Refusing Archive because the change set could not be proven."
+  exit 1
+}
+echo "==> Changed paths in this Xcode Cloud checkout:"
+echo "$CHANGED" | sed 's/^/    /'
+
+if ! printf '%s\n' "$CHANGED" | sh "$GATE"; then
+  echo "XCODE_CLOUD_SKIP: no iOS app source in this commit."
+  echo "Refusing Archive / App Store Connect upload for web, docs, or ci_scripts-only changes."
+  exit 1
+fi
+
+MARKETING_VERSION=$(sed -n 's/.*MARKETING_VERSION: *"\([^"]*\)".*/\1/p' "${REPO}/mobile/ios/project.yml" | head -1)
+echo "==> MARKETING_VERSION=${MARKETING_VERSION:-unset}"
+if [ -z "$MARKETING_VERSION" ] || stale_marketing_version "$MARKETING_VERSION"; then
+  echo "XCODE_CLOUD_SKIP: CFBundleShortVersionString ${MARKETING_VERSION:-empty} is not greater than live App Store 1.1."
+  echo "Do not upload. Next intentional iOS marketing version must be > 1.1 (project next train: 1.2)."
+  echo "Increasing CFBundleVersion / CURRENT_PROJECT_VERSION alone does not fix ITMS-90478."
+  exit 1
+fi
+
+IOS_DIR="${REPO}/mobile/ios"
 cd "$IOS_DIR"
 PBX="HiAir.xcodeproj/project.pbxproj"
 

--- a/mobile/ios/ci_scripts/ios_app_source_gate.sh
+++ b/mobile/ios/ci_scripts/ios_app_source_gate.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Exit 0 if stdin paths include iOS *app* source (not ci_scripts, web, or docs).
+# Exit 2 otherwise.
+# Paths are repository-relative, one per line.
+set -eu
+
+found=0
+while IFS= read -r path; do
+  [ -z "$path" ] && continue
+  case "$path" in
+    mobile/ios/HiAir/*|mobile/ios/HiAirTests/*|mobile/ios/project.yml|mobile/ios/HiAir.xcodeproj/*|mobile/ios/ExportOptions.plist|mobile/ios/HiAir.xcworkspace/*)
+      found=1
+      ;;
+  esac
+done
+
+if [ "$found" -eq 1 ]; then
+  exit 0
+fi
+exit 2

--- a/mobile/ios/ci_scripts/ios_release_gates.sh
+++ b/mobile/ios/ci_scripts/ios_release_gates.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+# Shared Xcode Cloud release gates. Source this file, or invoke:
+#   ios_release_gates.sh version <marketing>
+#     exit 0 = ALLOW VERSION GATE (not an upload)
+#     exit 1 = REJECT (marketing version <= live App Store 1.1)
+#   ios_release_gates.sh start
+#     uses CI_START_CONDITION / CI_TAG / CI_BRANCH
+#     exit 0 = release-intent present
+#     exit 1 = not a release start
+# CFBundleVersion / CURRENT_PROJECT_VERSION is intentionally unused.
+
+stale_marketing_version() {
+  case "$1" in
+    1.0|1.0.*|1.1|1.1.0) return 0 ;;
+  esac
+  return 1
+}
+
+explicit_ios_release_start() {
+  case "${CI_START_CONDITION:-}" in
+    manual|manual_rebuild) return 0 ;;
+  esac
+  if [ -n "${CI_TAG:-}" ]; then
+    case "$CI_TAG" in
+      ios-*|v[0-9]*|release-*) return 0 ;;
+    esac
+  fi
+  case "${CI_BRANCH:-}" in
+    release/*) return 0 ;;
+  esac
+  return 1
+}
+
+if [ "${0##*/}" = "ios_release_gates.sh" ]; then
+  cmd="${1:-}"
+  case "$cmd" in
+    version)
+      if [ -z "${2:-}" ]; then
+        echo "usage: ios_release_gates.sh version <marketing>" >&2
+        exit 2
+      fi
+      if stale_marketing_version "$2"; then
+        exit 1
+      fi
+      exit 0
+      ;;
+    start)
+      if explicit_ios_release_start; then
+        exit 0
+      fi
+      exit 1
+      ;;
+    *)
+      echo "usage: ios_release_gates.sh version <marketing> | start" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/mobile/ios/ci_scripts/test_ios_app_source_gate.sh
+++ b/mobile/ios/ci_scripts/test_ios_app_source_gate.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Local/CI check for ios_app_source_gate.sh — does not talk to App Store Connect.
+set -eu
+DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+GATE="$DIR/ios_app_source_gate.sh"
+
+assert_exit() {
+  expected="$1"
+  label="$2"
+  shift 2
+  set +e
+  printf '%s\n' "$@" | sh "$GATE"
+  actual=$?
+  set -e
+  if [ "$actual" -ne "$expected" ]; then
+    echo "FAIL $label: expected $expected got $actual" >&2
+    exit 1
+  fi
+  echo "PASS $label"
+}
+
+assert_exit 2 web_only 'web/index.html' 'web/sitemap.xml'
+assert_exit 2 docs_only 'docs/seo/SEARCH_FOUNDATION.md'
+assert_exit 2 ci_scripts_only 'mobile/ios/ci_scripts/ci_post_clone.sh' 'mobile/ios/ci_scripts/ios_app_source_gate.sh'
+assert_exit 0 project_yml 'mobile/ios/project.yml'
+assert_exit 0 swift_source 'web/index.html' 'mobile/ios/HiAir/HiAirApp.swift'
+assert_exit 0 xcodeproj 'mobile/ios/HiAir.xcodeproj/project.pbxproj'
+
+echo "All ios_app_source_gate checks passed."

--- a/mobile/ios/ci_scripts/test_ios_release_gates.sh
+++ b/mobile/ios/ci_scripts/test_ios_release_gates.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Local/CI checks for release-intent and marketing-version gates.
+# Does not talk to App Store Connect and does not upload a binary.
+set -eu
+DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+GATES="$DIR/ios_release_gates.sh"
+YML="$DIR/../project.yml"
+
+assert_version() {
+  expected="$1"
+  label="$2"
+  version="$3"
+  set +e
+  sh "$GATES" version "$version"
+  actual=$?
+  set -e
+  if [ "$actual" -ne "$expected" ]; then
+    echo "FAIL $label: expected exit $expected got $actual for $version" >&2
+    exit 1
+  fi
+  echo "PASS $label ($version)"
+}
+
+assert_start() {
+  expected="$1"
+  label="$2"
+  set +e
+  sh "$GATES" start
+  actual=$?
+  set -e
+  if [ "$actual" -ne "$expected" ]; then
+    echo "FAIL $label: expected exit $expected got $actual (CI_START_CONDITION=${CI_START_CONDITION-} CI_TAG=${CI_TAG-} CI_BRANCH=${CI_BRANCH-})" >&2
+    exit 1
+  fi
+  echo "PASS $label"
+}
+
+assert_version 1 reject_1.0.1 1.0.1
+assert_version 1 reject_1.1 1.1
+assert_version 1 reject_1.1.0 1.1.0
+assert_version 1 reject_1.0 1.0
+assert_version 0 allow_1.1.1 1.1.1
+assert_version 0 allow_1.2 1.2
+assert_version 0 allow_2.0 2.0
+
+# CFBundleVersion / CURRENT_PROJECT_VERSION must not affect the marketing gate.
+CURRENT_PROJECT_VERSION=9999 CI_BUILD_NUMBER=9999 assert_version 1 reject_1.0.1_with_high_build 1.0.1
+CURRENT_PROJECT_VERSION=9999 CI_BUILD_NUMBER=9999 assert_version 0 allow_1.2_with_any_build 1.2
+
+committed=$(sed -n 's/.*MARKETING_VERSION: *"\([^"]*\)".*/\1/p' "$YML" | head -1)
+if [ "$committed" != "1.0.1" ]; then
+  echo "FAIL committed MARKETING_VERSION is $committed (expected 1.0.1 on this branch)" >&2
+  exit 1
+fi
+assert_version 1 reject_committed_project_yml "$committed"
+echo "PASS project.yml MARKETING_VERSION is the CFBundleShortVersionString source ($committed)"
+
+CI_START_CONDITION=push CI_TAG= CI_BRANCH=main assert_start 1 push_main_is_not_release
+CI_START_CONDITION=pr_open CI_TAG= CI_BRANCH=seo/search-foundation assert_start 1 pr_is_not_release
+CI_START_CONDITION=schedule CI_TAG= CI_BRANCH=main assert_start 1 schedule_is_not_release
+CI_START_CONDITION=manual CI_TAG= CI_BRANCH=main assert_start 0 manual_is_release
+CI_START_CONDITION=manual_rebuild CI_TAG= CI_BRANCH=main assert_start 0 manual_rebuild_is_release
+CI_START_CONDITION=push CI_TAG=ios-1.2.0 CI_BRANCH=main assert_start 0 tag_ios_is_release
+CI_START_CONDITION=push CI_TAG= CI_BRANCH=release/ios-1.2 assert_start 0 release_branch_is_release
+
+echo "All ios_release_gates checks passed."

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -47,6 +47,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.hiair.app
         SWIFT_VERSION: 5.0
         CURRENT_PROJECT_VERSION: 215
+        # Live App Store is 1.1 (Apple ID 6773610034). Do not upload 1.0.1.
+        # Next intentional train is 1.2. Bump only on an explicit iOS release.
         MARKETING_VERSION: "1.0.1"
         INFOPLIST_KEY_CFBundleDisplayName: HiAir
         INFOPLIST_KEY_UILaunchStoryboardName: LaunchScreen


### PR DESCRIPTION
## Summary
- Stop Xcode Cloud Archive from uploading App Store binaries on web/docs/SEO pushes. `ci_post_clone.sh` now refuses automatic Archive unless the start is Manual, `release/*`, or an `ios-*` / `v*` / `release-*` tag, the diff contains iOS app source (not `ci_scripts` alone), and `MARKETING_VERSION` is greater than live store **1.1**.
- GitHub Actions **iOS CI** remains the compile/test path (`CODE_SIGNING_ALLOWED=NO`). It does not distribute.
- Documents the incident and policy in `docs/ios/XCODE_CLOUD_RELEASE_POLICY.md`. Does **not** bump `1.0.1` so an accidental upload cannot succeed.

## Why
Web commits on `seo/search-foundation` (and other non-iOS branches) started workflow **HiAir TestFlight**, archived, and delivered build 267 with `CFBundleShortVersionString = 1.0.1` against approved **1.1** (`ITMS-90478` / `ITMS-90186` / `ITMS-90062`).

`XCODE_CLOUD_REQUIRED = NO` (`main` has no branch protection / rulesets). A red Archive check on this PR is expected skip, not a merge blocker.

## Test plan
- [ ] Local `bash mobile/ios/ci_scripts/test_ios_app_source_gate.sh` (already passing)
- [ ] GitHub **iOS CI** simulator build/tests (no IPA upload)
- [ ] Xcode Cloud starts then logs `XCODE_CLOUD_SKIP` and does **not** deliver a binary to App Store Connect
- [ ] No `MARKETING_VERSION` bump; next intentional train remains **1.2** on an explicit release


Made with [Cursor](https://cursor.com)