### PR TITLE
feat(web): flag-off experiment instrumentation (Web Crypto, no treatment)

### DIFF
--- a/.github/workflows/hiair-io-pages.yml
+++ b/.github/workflows/hiair-io-pages.yml
@@ -50,7 +50,7 @@ jobs:
           node --check web/js/growth-experiment-config.js
           node --check web/js/growth-experiment-telemetry.js
           node --check web/js/growth-experiment-runtime.js
-          node --test web/js/store-links.test.cjs web/js/growth-telemetry.test.cjs web/js/growth-experiment.test.cjs
+          node --test web/js/store-links.test.cjs web/js/growth-telemetry.test.cjs web/js/growth-experiment.test.cjs web/js/growth-experiment-browser.test.cjs
 
   deploy:
     needs: validate

--- a/.github/workflows/hiair-io-pages.yml
+++ b/.github/workflows/hiair-io-pages.yml
@@ -45,7 +45,12 @@ jobs:
           python3 -m py_compile scripts/ops/generate_web_seo_content.py scripts/ops/check_web_seo.py scripts/ops/check_web_local_routes.py
           node --check web/js/store-links.js
           node --check web/js/main.js
-          node --test web/js/store-links.test.cjs web/js/growth-telemetry.test.cjs
+          node --check web/js/growth-experiment-assignment.js
+          node --check web/js/growth-experiment-exposure.js
+          node --check web/js/growth-experiment-config.js
+          node --check web/js/growth-experiment-telemetry.js
+          node --check web/js/growth-experiment-runtime.js
+          node --test web/js/store-links.test.cjs web/js/growth-telemetry.test.cjs web/js/growth-experiment.test.cjs
 
   deploy:
     needs: validate

--- a/docs/audits/HIAIR_EXPERIMENT_INSTRUMENTATION_BASELINE.md
+++ b/docs/audits/HIAIR_EXPERIMENT_INSTRUMENTATION_BASELINE.md
@@ -1,0 +1,41 @@
+# HiAir experiment instrumentation baseline
+
+**Generated:** 2026-08-31  
+**Production deploy this slice:** NO  
+**Experiment flag:** `HIAIR_EXPERIMENTS_ENABLED=false`
+
+## Production website source-of-truth
+
+GitHub default branch `cursor/bootstrap-ci-and-tooling` is **not** the marketing site source.
+
+| Fact | Value |
+| --- | --- |
+| Live origin | `https://hiair.io` (Cloudflare; `cf-ray`, `server: cloudflare`) |
+| Deploy workflow | `.github/workflows/hiair-io-pages.yml` |
+| Trigger | push to **`main`** paths `web/**`, `infra/cloudflare/**` |
+| Pages project | `hiair-web` (`wrangler pages deploy . --project-name=hiair-web --branch=production`) |
+| Domain proxy | Worker `infra/cloudflare/hiair-io-proxy` |
+| Website path in repo | `web/` |
+| Last successful Pages run | `33268279755` (2026-08-29T18:26:45Z) head `8d5f17bf3f97b370c3b64e5f3e5f88a27a48918d` |
+| Last `main` commit touching `web/` | `1e233658ad4c6ed147193be6798cb3b90e7d96eb` (`seo: search foundation for hiair.io`) |
+| `origin/main` at audit | `9aa2114cbc1456799c4bcc1b55fa42d328914ce2` (later CI-only commits; `web/` tree unchanged) |
+
+### Live vs `origin/main` `web/`
+
+| Asset | Result |
+| --- | --- |
+| `https://hiair.io/` HTML SHA-256 | **exact match** `origin/main:web/index.html` |
+| `https://hiair.io/js/main.js` | **exact match** after deploy inject of `GROWTH_OS_EVENTS_URL` → `https://growth-os-sable-psi.vercel.app/api/v1/events` |
+| Header CTA copy | `Download on the App Store` |
+
+Provenance is **proven**. Instrumentation may land on a branch from `main`. It must not merge or deploy in Slice 04.
+
+## Local workspace (do not use for this slice)
+
+`/Users/alex/Projects/HiAir` was on dirty `design/redesign-v4-deep-glass`. Slice 04 uses a clean worktree from `origin/main`:
+
+`/Users/alex/Projects/HiAir-slice04`
+
+## Open PRs (not website production)
+
+Several PRs still target `cursor/bootstrap-ci-and-tooling`. Website PRs that matter historically targeted `main` (e.g. Deep Glass redesign #47, live store CTAs). This slice’s HiAir PR must target **`main`**.

--- a/docs/engineering/EXPERIMENT_INSTRUMENTATION.md
+++ b/docs/engineering/EXPERIMENT_INSTRUMENTATION.md
@@ -1,18 +1,21 @@
 # HiAir experiment runtime (local / flag off)
 
-Not deployed. `HIAIR_EXPERIMENTS_ENABLED` is hardcoded `false` in `web/js/main.js`. Production HTML does not load the experiment modules.
+Not deployed. `HIAIR_EXPERIMENTS_ENABLED` is hardcoded `false` in `web/js/main.js`. Production HTML does not load the experiment modules (`store-links.js` + `main.js` only).
 
 ## Control fallback
 
-Any of: flag off, empty config, network failure, bad payload, bad variant, assignment failure, storage failure → **CONTROL**. Existing CTA copy stays `Download on the App Store`. No config request when the flag is false.
+Any of: flag off, empty config, network failure, bad payload, missing CONTROL, bad variant, assignment failure, crypto unavailable, storage unavailable, storage write failure, invalid treatment config → **CONTROL**. Existing CTA copy stays `Download on the App Store`. No config request when the flag is false.
 
 ## Assignment
 
 - Unit: **VISITOR** (`hiair_growth_anon`)
-- Hash: `SHA-256(experiment_id + ":" + assignment_version + ":" + anonymous_id)`
+- Hash: **async** `globalThis.crypto.subtle.digest("SHA-256", UTF-8 bytes)` of `experiment_id + ":" + assignment_version + ":" + anonymous_id`
+- Not CommonJS `require("crypto")`. Crypto failure does **not** collapse to bucket 0; it returns CONTROL.
 - Sticky key: `growth_experiment:<experiment_id>:<assignment_version>` in `localStorage`
+- Stored value must match experiment/version and a live allocation variant. Unknown variants are ignored.
+- Treatment requires a successful sticky write. `localStorage` missing or `setItem` failure → CONTROL.
 - New `session_id` must not re-randomize
-- Allocation change requires a new `assignment_version`
+- Allocation change for a running design requires a new `assignment_version`. v1 sticky must not leak into v2.
 
 ## Exposure
 

--- a/docs/engineering/EXPERIMENT_INSTRUMENTATION.md
+++ b/docs/engineering/EXPERIMENT_INSTRUMENTATION.md
@@ -1,0 +1,31 @@
+# HiAir experiment runtime (local / flag off)
+
+Not deployed. `HIAIR_EXPERIMENTS_ENABLED` is hardcoded `false` in `web/js/main.js`. Production HTML does not load the experiment modules.
+
+## Control fallback
+
+Any of: flag off, empty config, network failure, bad payload, bad variant, assignment failure, storage failure → **CONTROL**. Existing CTA copy stays `Download on the App Store`. No config request when the flag is false.
+
+## Assignment
+
+- Unit: **VISITOR** (`hiair_growth_anon`)
+- Hash: `SHA-256(experiment_id + ":" + assignment_version + ":" + anonymous_id)`
+- Sticky key: `growth_experiment:<experiment_id>:<assignment_version>` in `localStorage`
+- New `session_id` must not re-randomize
+- Allocation change requires a new `assignment_version`
+
+## Exposure
+
+`experiment.exposed` after IntersectionObserver ≥50% visible for ≥1000 ms. Not `app_store_cta.viewed`. Event id is deterministic; retry until transport succeeds.
+
+## Telemetry
+
+v2 fields: `experiment_id`, `variant_id`, `assignment_version`, `placement`, plus existing `anonymous_id` / `session_id`. Clicks reuse `app_store_cta.clicked` with those fields only when an experiment is active.
+
+## Mutations
+
+Allowlisted `cta_copy` via `textContent` only. No `eval`, script URLs, or HTML injection.
+
+## Rollback
+
+Set `HIAIR_EXPERIMENTS_ENABLED=false` (already the default) and omit experiment script tags. Existing CTA telemetry remains event_version 1.

--- a/web/js/assignment-golden-vectors.json
+++ b/web/js/assignment-golden-vectors.json
@@ -1,0 +1,199 @@
+{
+  "source": "python hashlib.sha256 utf-8; independent of Growth OS and HiAir implementations",
+  "hash": "SHA-256(experiment_id + ':' + assignment_version + ':' + anonymous_id)",
+  "bucket": "int(sha256_prefix, 16) / 0x1000000000000",
+  "allocation": [
+    {
+      "variant_id": "22222222-2222-4222-8222-222222222222",
+      "role": "CONTROL",
+      "weight": 0.5
+    },
+    {
+      "variant_id": "33333333-3333-4333-8333-333333333333",
+      "role": "TREATMENT",
+      "weight": 0.5
+    }
+  ],
+  "vectors": [
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-00",
+      "sha256_prefix": "b507d5bfd757",
+      "expected_bucket": 0.707150801979278,
+      "expected_role": "TREATMENT",
+      "expected_variant_id": "33333333-3333-4333-8333-333333333333"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-01",
+      "sha256_prefix": "4891f793db68",
+      "expected_bucket": 0.28347728118697546,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-02",
+      "sha256_prefix": "e7b854a29c9d",
+      "expected_bucket": 0.9051564118386644,
+      "expected_role": "TREATMENT",
+      "expected_variant_id": "33333333-3333-4333-8333-333333333333"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-03",
+      "sha256_prefix": "448049fab1cf",
+      "expected_bucket": 0.2675825345084455,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-04",
+      "sha256_prefix": "675deb8d997f",
+      "expected_bucket": 0.40377685744305936,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-05",
+      "sha256_prefix": "7c5c3b12b161",
+      "expected_bucket": 0.4857823296200685,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-06",
+      "sha256_prefix": "625301aa5706",
+      "expected_bucket": 0.38407907875718905,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-07",
+      "sha256_prefix": "32af00294734",
+      "expected_bucket": 0.19798279769675275,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-08",
+      "sha256_prefix": "0e4a47f3f337",
+      "expected_bucket": 0.05582093911945307,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "anon-golden-09",
+      "sha256_prefix": "155b126a8a8c",
+      "expected_bucket": 0.08342089749434933,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "visitor-A",
+      "sha256_prefix": "f06658c1fc1c",
+      "expected_bucket": 0.9390616868587216,
+      "expected_role": "TREATMENT",
+      "expected_variant_id": "33333333-3333-4333-8333-333333333333"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "visitor-B",
+      "sha256_prefix": "ed93798954d3",
+      "expected_bucket": 0.9280315361291507,
+      "expected_role": "TREATMENT",
+      "expected_variant_id": "33333333-3333-4333-8333-333333333333"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "pop-0",
+      "sha256_prefix": "5f33b73bcffa",
+      "expected_bucket": 0.37188286981834295,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "pop-1",
+      "sha256_prefix": "abafa5f0fd07",
+      "expected_bucket": 0.670648928961807,
+      "expected_role": "TREATMENT",
+      "expected_variant_id": "33333333-3333-4333-8333-333333333333"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "pop-42",
+      "sha256_prefix": "f4154c96b1b9",
+      "expected_bucket": 0.9534499996095498,
+      "expected_role": "TREATMENT",
+      "expected_variant_id": "33333333-3333-4333-8333-333333333333"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "pop-999",
+      "sha256_prefix": "bfb06a336a03",
+      "expected_bucket": 0.7487856269381261,
+      "expected_role": "TREATMENT",
+      "expected_variant_id": "33333333-3333-4333-8333-333333333333"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "sticky-0",
+      "sha256_prefix": "955800d4e9e1",
+      "expected_bucket": 0.5833740730103081,
+      "expected_role": "TREATMENT",
+      "expected_variant_id": "33333333-3333-4333-8333-333333333333"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "cross-session-1",
+      "sha256_prefix": "29ecdc43fc7b",
+      "expected_bucket": 0.16377045306988336,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "new-visitor-x",
+      "sha256_prefix": "03372456f7a5",
+      "expected_bucket": 0.012560149414316157,
+      "expected_role": "CONTROL",
+      "expected_variant_id": "22222222-2222-4222-8222-222222222222"
+    },
+    {
+      "experiment_id": "11111111-1111-4111-8111-111111111111",
+      "assignment_version": "v1",
+      "anonymous_id": "unicode-visítor",
+      "sha256_prefix": "bd9f8a084494",
+      "expected_bucket": 0.7407156248269331,
+      "expected_role": "TREATMENT",
+      "expected_variant_id": "33333333-3333-4333-8333-333333333333"
+    }
+  ]
+}

--- a/web/js/growth-experiment-assignment.js
+++ b/web/js/growth-experiment-assignment.js
@@ -1,0 +1,122 @@
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  root.HIAIR_GROWTH_ASSIGNMENT = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  var STORAGE_PREFIX = "growth_experiment:";
+
+  function sha256Hex(value) {
+    var nodeCrypto = typeof require === "function" ? require("crypto") : null;
+    if (nodeCrypto && typeof nodeCrypto.createHash === "function") {
+      return nodeCrypto.createHash("sha256").update(value, "utf8").digest("hex");
+    }
+    return null;
+  }
+
+  function bucket(experimentId, assignmentVersion, anonymousId) {
+    var hex = sha256Hex(experimentId + ":" + assignmentVersion + ":" + anonymousId);
+    if (!hex) {
+      return 0;
+    }
+    return parseInt(hex.slice(0, 12), 16) / 0x1000000000000;
+  }
+
+  function controlVariant(allocation) {
+    if (!allocation || !allocation.length) {
+      return null;
+    }
+    for (var i = 0; i < allocation.length; i += 1) {
+      if (allocation[i].role === "CONTROL") {
+        return allocation[i];
+      }
+    }
+    return allocation[0];
+  }
+
+  function assignFromHash(input) {
+    var allocation = input.allocation || [];
+    var fallback = controlVariant(allocation);
+    if (!input.experimentId || !input.anonymousId || !input.assignmentVersion || !fallback) {
+      return fallback
+        ? { variant_id: fallback.variant_id, role: fallback.role, source: "control_fallback" }
+        : null;
+    }
+    var total = 0;
+    for (var i = 0; i < allocation.length; i += 1) {
+      total += Number(allocation[i].weight) || 0;
+    }
+    if (total <= 0) {
+      return { variant_id: fallback.variant_id, role: fallback.role, source: "control_fallback" };
+    }
+    var point = bucket(input.experimentId, input.assignmentVersion, input.anonymousId);
+    var cursor = 0;
+    for (var j = 0; j < allocation.length; j += 1) {
+      cursor += (Number(allocation[j].weight) || 0) / total;
+      if (point < cursor) {
+        return { variant_id: allocation[j].variant_id, role: allocation[j].role, source: "hash" };
+      }
+    }
+    var last = allocation[allocation.length - 1];
+    return { variant_id: last.variant_id, role: last.role, source: "hash" };
+  }
+
+  function storageKey(experimentId, assignmentVersion) {
+    return STORAGE_PREFIX + experimentId + ":" + assignmentVersion;
+  }
+
+  function readSticky(storage, experimentId, assignmentVersion) {
+    try {
+      var raw = storage.getItem(storageKey(experimentId, assignmentVersion));
+      if (!raw) {
+        return null;
+      }
+      var parsed = JSON.parse(raw);
+      if (parsed && typeof parsed.variant_id === "string") {
+        return parsed;
+      }
+    } catch (error) {
+      return null;
+    }
+    return null;
+  }
+
+  function writeSticky(storage, experimentId, assignmentVersion, variantId) {
+    try {
+      storage.setItem(
+        storageKey(experimentId, assignmentVersion),
+        JSON.stringify({ variant_id: variantId, assigned_at: new Date().toISOString() }),
+      );
+    } catch (error) {
+      return;
+    }
+  }
+
+  function assignVisitor(input) {
+    var storage = input.storage;
+    var hashed = assignFromHash(input);
+    if (!hashed) {
+      return null;
+    }
+    if (storage) {
+      var sticky = readSticky(storage, input.experimentId, input.assignmentVersion);
+      if (sticky && sticky.variant_id) {
+        var known = (input.allocation || []).find(function (row) {
+          return row.variant_id === sticky.variant_id;
+        });
+        if (known) {
+          return { variant_id: known.variant_id, role: known.role, source: "sticky" };
+        }
+      }
+      writeSticky(storage, input.experimentId, input.assignmentVersion, hashed.variant_id);
+    }
+    return hashed;
+  }
+
+  return {
+    assignVisitor: assignVisitor,
+    assignFromHash: assignFromHash,
+    storageKey: storageKey,
+  };
+});

--- a/web/js/growth-experiment-assignment.js
+++ b/web/js/growth-experiment-assignment.js
@@ -6,21 +6,54 @@
   root.HIAIR_GROWTH_ASSIGNMENT = api;
 })(typeof globalThis !== "undefined" ? globalThis : this, function () {
   var STORAGE_PREFIX = "growth_experiment:";
+  var BUCKET_DIVISOR = 0x1000000000000;
 
-  function sha256Hex(value) {
-    var nodeCrypto = typeof require === "function" ? require("crypto") : null;
-    if (nodeCrypto && typeof nodeCrypto.createHash === "function") {
-      return nodeCrypto.createHash("sha256").update(value, "utf8").digest("hex");
-    }
-    return null;
+  function webCrypto() {
+    return typeof globalThis !== "undefined" && globalThis.crypto ? globalThis.crypto : null;
   }
 
-  function bucket(experimentId, assignmentVersion, anonymousId) {
-    var hex = sha256Hex(experimentId + ":" + assignmentVersion + ":" + anonymousId);
-    if (!hex) {
-      return 0;
+  function bytesToHex(buffer) {
+    var view = new Uint8Array(buffer);
+    var hex = "";
+    for (var i = 0; i < view.length; i += 1) {
+      var part = view[i].toString(16);
+      hex += part.length === 1 ? "0" + part : part;
     }
-    return parseInt(hex.slice(0, 12), 16) / 0x1000000000000;
+    return hex;
+  }
+
+  /**
+   * Browser-native SHA-256. Never uses CommonJS require("crypto").
+   * Returns null when Web Crypto is missing or throws (fail closed).
+   */
+  function sha256Hex(value) {
+    var cryptoObj = webCrypto();
+    if (!cryptoObj || !cryptoObj.subtle || typeof cryptoObj.subtle.digest !== "function") {
+      return Promise.resolve(null);
+    }
+    if (typeof TextEncoder !== "function") {
+      return Promise.resolve(null);
+    }
+    var bytes;
+    try {
+      bytes = new TextEncoder().encode(value);
+    } catch (error) {
+      return Promise.resolve(null);
+    }
+    return cryptoObj.subtle.digest("SHA-256", bytes).then(bytesToHex).catch(function () {
+      return null;
+    });
+  }
+
+  function bucketFromHex(hex) {
+    if (!hex || typeof hex !== "string" || hex.length < 12) {
+      return null;
+    }
+    var bits = parseInt(hex.slice(0, 12), 16);
+    if (!isFinite(bits)) {
+      return null;
+    }
+    return bits / BUCKET_DIVISOR;
   }
 
   function controlVariant(allocation) {
@@ -32,91 +65,196 @@
         return allocation[i];
       }
     }
-    return allocation[0];
+    return null;
+  }
+
+  function findVariant(allocation, variantId) {
+    if (!allocation || !variantId) {
+      return null;
+    }
+    for (var i = 0; i < allocation.length; i += 1) {
+      if (allocation[i].variant_id === variantId) {
+        return allocation[i];
+      }
+    }
+    return null;
+  }
+
+  function controlResult(allocation, reason) {
+    var fallback = controlVariant(allocation);
+    if (!fallback) {
+      return null;
+    }
+    return {
+      variant_id: fallback.variant_id,
+      role: "CONTROL",
+      source: "control_fallback",
+      reason: reason || "control_fallback",
+      bucket: null,
+    };
   }
 
   function assignFromHash(input) {
-    var allocation = input.allocation || [];
-    var fallback = controlVariant(allocation);
-    if (!input.experimentId || !input.anonymousId || !input.assignmentVersion || !fallback) {
-      return fallback
-        ? { variant_id: fallback.variant_id, role: fallback.role, source: "control_fallback" }
-        : null;
+    var allocation = (input && input.allocation) || [];
+    if (!input || !input.experimentId || !input.anonymousId || !input.assignmentVersion) {
+      return Promise.resolve(controlResult(allocation, "missing_identity"));
+    }
+    if (!controlVariant(allocation)) {
+      return Promise.resolve(controlResult(allocation, "missing_control"));
     }
     var total = 0;
     for (var i = 0; i < allocation.length; i += 1) {
-      total += Number(allocation[i].weight) || 0;
+      var weight = Number(allocation[i].weight);
+      if (!isFinite(weight) || weight < 0) {
+        return Promise.resolve(controlResult(allocation, "invalid_weight"));
+      }
+      total += weight;
     }
     if (total <= 0) {
-      return { variant_id: fallback.variant_id, role: fallback.role, source: "control_fallback" };
+      return Promise.resolve(controlResult(allocation, "invalid_allocation"));
     }
-    var point = bucket(input.experimentId, input.assignmentVersion, input.anonymousId);
-    var cursor = 0;
-    for (var j = 0; j < allocation.length; j += 1) {
-      cursor += (Number(allocation[j].weight) || 0) / total;
-      if (point < cursor) {
-        return { variant_id: allocation[j].variant_id, role: allocation[j].role, source: "hash" };
+    var material = input.experimentId + ":" + input.assignmentVersion + ":" + input.anonymousId;
+    return sha256Hex(material).then(function (hex) {
+      var point = bucketFromHex(hex);
+      if (point == null) {
+        return controlResult(allocation, "crypto_unavailable");
       }
-    }
-    var last = allocation[allocation.length - 1];
-    return { variant_id: last.variant_id, role: last.role, source: "hash" };
+      var cursor = 0;
+      for (var j = 0; j < allocation.length; j += 1) {
+        cursor += Number(allocation[j].weight) / total;
+        if (point < cursor) {
+          var chosen = allocation[j];
+          if (chosen.role !== "CONTROL" && chosen.role !== "TREATMENT") {
+            return controlResult(allocation, "invalid_role");
+          }
+          return {
+            variant_id: chosen.variant_id,
+            role: chosen.role,
+            source: "hash",
+            bucket: point,
+            sha256_prefix: hex.slice(0, 12),
+          };
+        }
+      }
+      var last = allocation[allocation.length - 1];
+      if (!last || (last.role !== "CONTROL" && last.role !== "TREATMENT")) {
+        return controlResult(allocation, "invalid_role");
+      }
+      return {
+        variant_id: last.variant_id,
+        role: last.role,
+        source: "hash",
+        bucket: point,
+        sha256_prefix: hex.slice(0, 12),
+      };
+    });
   }
 
   function storageKey(experimentId, assignmentVersion) {
     return STORAGE_PREFIX + experimentId + ":" + assignmentVersion;
   }
 
-  function readSticky(storage, experimentId, assignmentVersion) {
+  function parseSticky(raw, experimentId, assignmentVersion, allocation) {
+    if (!raw) {
+      return null;
+    }
+    var parsed;
     try {
-      var raw = storage.getItem(storageKey(experimentId, assignmentVersion));
-      if (!raw) {
-        return null;
-      }
-      var parsed = JSON.parse(raw);
-      if (parsed && typeof parsed.variant_id === "string") {
-        return parsed;
-      }
+      parsed = JSON.parse(raw);
     } catch (error) {
       return null;
     }
-    return null;
+    if (!parsed || typeof parsed.variant_id !== "string") {
+      return null;
+    }
+    if (parsed.experiment_id && parsed.experiment_id !== experimentId) {
+      return null;
+    }
+    if (parsed.assignment_version && parsed.assignment_version !== assignmentVersion) {
+      return null;
+    }
+    var known = findVariant(allocation, parsed.variant_id);
+    if (!known) {
+      return null;
+    }
+    if (known.role !== "CONTROL" && known.role !== "TREATMENT") {
+      return null;
+    }
+    return known;
+  }
+
+  function readSticky(storage, experimentId, assignmentVersion, allocation) {
+    if (!storage || typeof storage.getItem !== "function") {
+      return null;
+    }
+    try {
+      return parseSticky(storage.getItem(storageKey(experimentId, assignmentVersion)), experimentId, assignmentVersion, allocation);
+    } catch (error) {
+      return null;
+    }
   }
 
   function writeSticky(storage, experimentId, assignmentVersion, variantId) {
+    if (!storage || typeof storage.setItem !== "function" || typeof storage.getItem !== "function") {
+      return false;
+    }
+    var key = storageKey(experimentId, assignmentVersion);
+    var payload = JSON.stringify({
+      variant_id: variantId,
+      assigned_at: new Date().toISOString(),
+      experiment_id: experimentId,
+      assignment_version: assignmentVersion,
+    });
     try {
-      storage.setItem(
-        storageKey(experimentId, assignmentVersion),
-        JSON.stringify({ variant_id: variantId, assigned_at: new Date().toISOString() }),
-      );
+      storage.setItem(key, payload);
+      var raw = storage.getItem(key);
+      if (!raw) {
+        return false;
+      }
+      var parsed = JSON.parse(raw);
+      return parsed && parsed.variant_id === variantId;
     } catch (error) {
-      return;
+      return false;
     }
   }
 
+  /**
+   * Visitor assignment. Treatment requires durable stickiness.
+   * Missing storage, write failure, or crypto failure → CONTROL.
+   */
   function assignVisitor(input) {
-    var storage = input.storage;
-    var hashed = assignFromHash(input);
-    if (!hashed) {
-      return null;
+    var allocation = (input && input.allocation) || [];
+    var storage = input && input.storage;
+    if (!storage || typeof storage.getItem !== "function" || typeof storage.setItem !== "function") {
+      return Promise.resolve(controlResult(allocation, "storage_unavailable"));
     }
-    if (storage) {
-      var sticky = readSticky(storage, input.experimentId, input.assignmentVersion);
-      if (sticky && sticky.variant_id) {
-        var known = (input.allocation || []).find(function (row) {
-          return row.variant_id === sticky.variant_id;
-        });
-        if (known) {
-          return { variant_id: known.variant_id, role: known.role, source: "sticky" };
-        }
+    var sticky = readSticky(storage, input.experimentId, input.assignmentVersion, allocation);
+    if (sticky) {
+      return Promise.resolve({
+        variant_id: sticky.variant_id,
+        role: sticky.role,
+        source: "sticky",
+      });
+    }
+    return assignFromHash(input).then(function (hashed) {
+      if (!hashed) {
+        return controlResult(allocation, "assignment_failure");
       }
-      writeSticky(storage, input.experimentId, input.assignmentVersion, hashed.variant_id);
-    }
-    return hashed;
+      if (hashed.source !== "hash") {
+        return hashed;
+      }
+      if (!writeSticky(storage, input.experimentId, input.assignmentVersion, hashed.variant_id)) {
+        return controlResult(allocation, "storage_write_failure");
+      }
+      return hashed;
+    });
   }
 
   return {
     assignVisitor: assignVisitor,
     assignFromHash: assignFromHash,
     storageKey: storageKey,
+    sha256Hex: sha256Hex,
+    bucketFromHex: bucketFromHex,
   };
 });

--- a/web/js/growth-experiment-browser.test.cjs
+++ b/web/js/growth-experiment-browser.test.cjs
@@ -1,0 +1,170 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const { webcrypto } = require("node:crypto");
+
+const golden = JSON.parse(fs.readFileSync(path.join(__dirname, "assignment-golden-vectors.json"), "utf8"));
+const EXPERIMENT_ID = "11111111-1111-4111-8111-111111111111";
+const CONTROL = "22222222-2222-4222-8222-222222222222";
+const TREATMENT = "33333333-3333-4333-8333-333333333333";
+const allocation = golden.allocation;
+
+function memoryStorage() {
+  const mem = new Map();
+  return {
+    getItem: (key) => mem.get(key) ?? null,
+    setItem: (key, value) => mem.set(key, String(value)),
+  };
+}
+
+function loadAssignment(options) {
+  const source = fs.readFileSync(path.join(__dirname, "growth-experiment-assignment.js"), "utf8");
+  const sandbox = {
+    crypto: options && Object.prototype.hasOwnProperty.call(options, "crypto") ? options.crypto : webcrypto,
+    TextEncoder,
+    Uint8Array,
+    Promise,
+    Date,
+    JSON,
+    Array,
+    Object,
+    Math,
+    Number,
+    String,
+    Boolean,
+    parseInt,
+    isFinite,
+    console,
+  };
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  assert.equal(typeof sandbox.require, "undefined");
+  assert.equal(typeof sandbox.module, "undefined");
+  vm.runInContext(source, sandbox);
+  assert.ok(sandbox.HIAIR_GROWTH_ASSIGNMENT);
+  return sandbox.HIAIR_GROWTH_ASSIGNMENT;
+}
+
+test("browser runtime has no require and uses Web Crypto", async () => {
+  const api = loadAssignment();
+  const buckets = new Set();
+  for (const vector of golden.vectors) {
+    const assigned = await api.assignFromHash({
+      experimentId: vector.experiment_id,
+      assignmentVersion: vector.assignment_version,
+      anonymousId: vector.anonymous_id,
+      allocation,
+    });
+    assert.equal(assigned.source, "hash", vector.anonymous_id);
+    assert.equal(assigned.sha256_prefix, vector.sha256_prefix, vector.anonymous_id);
+    assert.equal(assigned.role, vector.expected_role, vector.anonymous_id);
+    buckets.add(assigned.bucket);
+  }
+  assert.equal(golden.vectors.length, 20);
+  assert.ok(buckets.size > 1);
+  assert.ok(![...buckets].every((value) => value === 0));
+});
+
+test("browser assignment is not always bucket 0", async () => {
+  const api = loadAssignment();
+  const first = await api.assignFromHash({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-golden-00",
+    allocation,
+  });
+  const second = await api.assignFromHash({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-golden-01",
+    allocation,
+  });
+  assert.notEqual(first.bucket, 0);
+  assert.notEqual(first.bucket, second.bucket);
+  assert.equal(first.role, "TREATMENT");
+  assert.equal(second.role, "CONTROL");
+});
+
+test("browser crypto unavailable fails closed to CONTROL", async () => {
+  const api = loadAssignment({ crypto: undefined });
+  const assigned = await api.assignFromHash({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-golden-00",
+    allocation,
+  });
+  assert.equal(assigned.role, "CONTROL");
+  assert.equal(assigned.source, "control_fallback");
+  assert.equal(assigned.reason, "crypto_unavailable");
+});
+
+test("10k browser Web Crypto assignments stay near 50/50", async () => {
+  const api = loadAssignment();
+  const pending = [];
+  for (let i = 0; i < 10000; i += 1) {
+    pending.push(
+      api.assignFromHash({
+        experimentId: EXPERIMENT_ID,
+        assignmentVersion: "v1",
+        anonymousId: "pop-" + i,
+        allocation,
+      }),
+    );
+  }
+  const assigned = await Promise.all(pending);
+  let control = 0;
+  let treatment = 0;
+  let hashSource = 0;
+  for (const row of assigned) {
+    assert.notEqual(row.source, "control_fallback");
+    if (row.role === "CONTROL") {
+      control += 1;
+    } else if (row.role === "TREATMENT") {
+      treatment += 1;
+    }
+    if (row.source === "hash") {
+      hashSource += 1;
+    }
+  }
+  assert.equal(hashSource, 10000);
+  assert.notEqual(control, 10000);
+  assert.ok(control >= 4700 && control <= 5300, "CONTROL=" + control);
+  assert.ok(treatment >= 4700 && treatment <= 5300, "TREATMENT=" + treatment);
+  globalThis.__HIAIR_BROWSER_10K__ = { control, treatment };
+});
+
+test("1000 browser sticky visitors stay put across reload and new session", async () => {
+  const storage = memoryStorage();
+  const firstApi = loadAssignment();
+  let switches = 0;
+  const firstIds = [];
+  for (let i = 0; i < 1000; i += 1) {
+    const assigned = await firstApi.assignVisitor({
+      experimentId: EXPERIMENT_ID,
+      assignmentVersion: "v1",
+      anonymousId: "sticky-pop-" + i,
+      allocation,
+      storage,
+      sessionId: "session-a-" + i,
+    });
+    firstIds.push(assigned.variant_id);
+  }
+  const reloaded = loadAssignment();
+  for (let i = 0; i < 1000; i += 1) {
+    const again = await reloaded.assignVisitor({
+      experimentId: EXPERIMENT_ID,
+      assignmentVersion: "v1",
+      anonymousId: "sticky-pop-" + i,
+      allocation,
+      storage,
+      sessionId: "session-b-" + i,
+    });
+    assert.equal(again.source, "sticky");
+    if (again.variant_id !== firstIds[i]) {
+      switches += 1;
+    }
+  }
+  assert.equal(switches, 0);
+});

--- a/web/js/growth-experiment-config.js
+++ b/web/js/growth-experiment-config.js
@@ -1,0 +1,68 @@
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  root.HIAIR_GROWTH_EXPERIMENT_CONFIG = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  function empty() {
+    return { experiments: [] };
+  }
+
+  function sanitizeCtaCopy(value) {
+    if (typeof value !== "string") {
+      return null;
+    }
+    var clipped = value.replace(/[\u0000-\u001f]/g, "").trim().slice(0, 80);
+    if (!clipped || clipped.indexOf("@") >= 0 || /<script/i.test(clipped) || /<\/?[a-z]/i.test(clipped) || /\beval\b/i.test(clipped)) {
+      return null;
+    }
+    return clipped;
+  }
+
+  function publicConfig(raw) {
+    var copy = sanitizeCtaCopy(raw && raw.cta_copy);
+    return copy ? { cta_copy: copy } : {};
+  }
+
+  function failClosedFetch(input) {
+    if (!input.enabled) {
+      return Promise.resolve(empty());
+    }
+    if (!input.url || !input.fetch) {
+      return Promise.resolve(empty());
+    }
+    return input
+      .fetch(input.url, { method: "GET", headers: { accept: "application/json" } })
+      .then(function (response) {
+        if (!response || !response.ok) {
+          return empty();
+        }
+        return response.json();
+      })
+      .then(function (body) {
+        if (!body || !Array.isArray(body.experiments)) {
+          return empty();
+        }
+        return body;
+      })
+      .catch(function () {
+        return empty();
+      });
+  }
+
+  function applyCtaCopy(el, copy) {
+    if (!el || !copy) {
+      return false;
+    }
+    el.textContent = copy;
+    return true;
+  }
+
+  return {
+    empty: empty,
+    publicConfig: publicConfig,
+    failClosedFetch: failClosedFetch,
+    applyCtaCopy: applyCtaCopy,
+  };
+});

--- a/web/js/growth-experiment-exposure.js
+++ b/web/js/growth-experiment-exposure.js
@@ -1,0 +1,75 @@
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  root.HIAIR_GROWTH_EXPOSURE = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  var THRESHOLD = 0.5;
+  var MIN_DURATION_MS = 1000;
+  var CONTRACT_VERSION = "io-50pct-1000ms-v1";
+
+  function conditionMet(intersectionRatio, visibleMs) {
+    return intersectionRatio >= THRESHOLD && visibleMs >= MIN_DURATION_MS;
+  }
+
+  function exposureEventId(input) {
+    return [
+      "experiment.exposed",
+      input.experimentId,
+      input.variantId,
+      input.anonymousId,
+      input.placement,
+      CONTRACT_VERSION,
+    ].join(":");
+  }
+
+  /**
+   * Fake-timer friendly watcher. `now()` and `observe` are injected.
+   * Does not mark an exposure as sent until `send()` resolves.
+   */
+  function watchExposure(input) {
+    var visibleSince = null;
+    var inflight = false;
+    var sent = false;
+    var now = input.now || function () {
+      return Date.now();
+    };
+    var send = input.send;
+
+    function onRatio(ratio) {
+      if (sent || inflight) {
+        return;
+      }
+      if (ratio < THRESHOLD) {
+        visibleSince = null;
+        return;
+      }
+      if (visibleSince == null) {
+        visibleSince = now();
+      }
+      if (now() - visibleSince >= MIN_DURATION_MS) {
+        inflight = true;
+        Promise.resolve(send(exposureEventId(input)))
+          .then(function () {
+            sent = true;
+            inflight = false;
+          })
+          .catch(function () {
+            inflight = false;
+          });
+      }
+    }
+
+    return { onRatio: onRatio, conditionMet: conditionMet };
+  }
+
+  return {
+    THRESHOLD: THRESHOLD,
+    MIN_DURATION_MS: MIN_DURATION_MS,
+    CONTRACT_VERSION: CONTRACT_VERSION,
+    conditionMet: conditionMet,
+    exposureEventId: exposureEventId,
+    watchExposure: watchExposure,
+  };
+});

--- a/web/js/growth-experiment-runtime.js
+++ b/web/js/growth-experiment-runtime.js
@@ -1,0 +1,88 @@
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  root.HIAIR_GROWTH_EXPERIMENT = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  var CONTROL_COPY = "Download on the App Store";
+
+  function start(input) {
+    var enabled = Boolean(input && input.enabled);
+    var configApi = (input && input.configApi) || {};
+    var assignmentApi = (input && input.assignmentApi) || {};
+    var telemetryApi = (input && input.telemetryApi) || {};
+    var exposureApi = (input && input.exposureApi) || {};
+    if (!enabled) {
+      return Promise.resolve({ variant: "CONTROL", reason: "flag_off" });
+    }
+    return (configApi.failClosedFetch
+      ? configApi.failClosedFetch({
+          enabled: true,
+          url: input.configUrl,
+          fetch: input.fetch,
+        })
+      : Promise.resolve({ experiments: [] })
+    )
+      .then(function (payload) {
+        var experiment = payload && payload.experiments && payload.experiments[0];
+        if (!experiment) {
+          return { variant: "CONTROL", reason: "no_active_experiment" };
+        }
+        var assigned = assignmentApi.assignVisitor({
+          experimentId: experiment.id,
+          assignmentVersion: experiment.assignment_version,
+          anonymousId: input.anonymousId,
+          allocation: experiment.allocation,
+          storage: input.storage,
+        });
+        if (!assigned || !assigned.variant_id) {
+          return { variant: "CONTROL", reason: "assignment_failure" };
+        }
+        var chosen = (experiment.allocation || []).find(function (row) {
+          return row.variant_id === assigned.variant_id;
+        });
+        if (!chosen) {
+          return { variant: "CONTROL", reason: "bad_variant" };
+        }
+        if (chosen.role === "TREATMENT" && chosen.public_config && chosen.public_config.cta_copy && input.ctaEl) {
+          configApi.applyCtaCopy(input.ctaEl, chosen.public_config.cta_copy);
+        } else if (input.ctaEl && !input.ctaEl.textContent) {
+          input.ctaEl.textContent = CONTROL_COPY;
+        }
+        var assignmentId = telemetryApi.assignmentEventId(
+          experiment.id,
+          input.anonymousId,
+          experiment.assignment_version,
+        );
+        return telemetryApi
+          .send({
+            url: input.eventsUrl,
+            fetch: input.fetch,
+            name: "experiment.assigned",
+            eventId: assignmentId,
+            anonymousId: input.anonymousId,
+            sessionId: input.sessionId,
+            experimentId: experiment.id,
+            variantId: chosen.variant_id,
+            assignmentVersion: experiment.assignment_version,
+            placement: experiment.placement,
+          })
+          .then(function () {
+            return {
+              variant: chosen.role,
+              experiment: experiment,
+              variantId: chosen.variant_id,
+            };
+          })
+          .catch(function () {
+            return { variant: "CONTROL", reason: "telemetry_failure" };
+          });
+      })
+      .catch(function () {
+        return { variant: "CONTROL", reason: "network_failure" };
+      });
+  }
+
+  return { start: start, CONTROL_COPY: CONTROL_COPY };
+});

--- a/web/js/growth-experiment-runtime.js
+++ b/web/js/growth-experiment-runtime.js
@@ -7,14 +7,29 @@
 })(typeof globalThis !== "undefined" ? globalThis : this, function () {
   var CONTROL_COPY = "Download on the App Store";
 
+  function control(reason) {
+    return { variant: "CONTROL", reason: reason };
+  }
+
+  function hasControl(allocation) {
+    if (!allocation || !allocation.length) {
+      return false;
+    }
+    for (var i = 0; i < allocation.length; i += 1) {
+      if (allocation[i].role === "CONTROL") {
+        return true;
+      }
+    }
+    return false;
+  }
+
   function start(input) {
     var enabled = Boolean(input && input.enabled);
     var configApi = (input && input.configApi) || {};
     var assignmentApi = (input && input.assignmentApi) || {};
     var telemetryApi = (input && input.telemetryApi) || {};
-    var exposureApi = (input && input.exposureApi) || {};
     if (!enabled) {
-      return Promise.resolve({ variant: "CONTROL", reason: "flag_off" });
+      return Promise.resolve(control("flag_off"));
     }
     return (configApi.failClosedFetch
       ? configApi.failClosedFetch({
@@ -26,61 +41,77 @@
     )
       .then(function (payload) {
         var experiment = payload && payload.experiments && payload.experiments[0];
-        if (!experiment) {
-          return { variant: "CONTROL", reason: "no_active_experiment" };
+        if (!experiment || !experiment.id || !experiment.assignment_version || !Array.isArray(experiment.allocation)) {
+          return control("no_active_experiment");
         }
-        var assigned = assignmentApi.assignVisitor({
-          experimentId: experiment.id,
-          assignmentVersion: experiment.assignment_version,
-          anonymousId: input.anonymousId,
-          allocation: experiment.allocation,
-          storage: input.storage,
-        });
-        if (!assigned || !assigned.variant_id) {
-          return { variant: "CONTROL", reason: "assignment_failure" };
+        if (!hasControl(experiment.allocation)) {
+          return control("missing_control");
         }
-        var chosen = (experiment.allocation || []).find(function (row) {
-          return row.variant_id === assigned.variant_id;
-        });
-        if (!chosen) {
-          return { variant: "CONTROL", reason: "bad_variant" };
+        if (typeof assignmentApi.assignVisitor !== "function") {
+          return control("assignment_failure");
         }
-        if (chosen.role === "TREATMENT" && chosen.public_config && chosen.public_config.cta_copy && input.ctaEl) {
-          configApi.applyCtaCopy(input.ctaEl, chosen.public_config.cta_copy);
-        } else if (input.ctaEl && !input.ctaEl.textContent) {
-          input.ctaEl.textContent = CONTROL_COPY;
-        }
-        var assignmentId = telemetryApi.assignmentEventId(
-          experiment.id,
-          input.anonymousId,
-          experiment.assignment_version,
-        );
-        return telemetryApi
-          .send({
-            url: input.eventsUrl,
-            fetch: input.fetch,
-            name: "experiment.assigned",
-            eventId: assignmentId,
-            anonymousId: input.anonymousId,
-            sessionId: input.sessionId,
+        return Promise.resolve(
+          assignmentApi.assignVisitor({
             experimentId: experiment.id,
-            variantId: chosen.variant_id,
             assignmentVersion: experiment.assignment_version,
-            placement: experiment.placement,
-          })
-          .then(function () {
-            return {
-              variant: chosen.role,
-              experiment: experiment,
-              variantId: chosen.variant_id,
-            };
-          })
-          .catch(function () {
-            return { variant: "CONTROL", reason: "telemetry_failure" };
+            anonymousId: input.anonymousId,
+            allocation: experiment.allocation,
+            storage: input.storage,
+          }),
+        ).then(function (assigned) {
+          if (!assigned || !assigned.variant_id) {
+            return control("assignment_failure");
+          }
+          var chosen = (experiment.allocation || []).find(function (row) {
+            return row.variant_id === assigned.variant_id;
           });
+          if (!chosen) {
+            return control("bad_variant");
+          }
+          if (chosen.role === "TREATMENT") {
+            var sanitized = configApi.publicConfig ? configApi.publicConfig(chosen.public_config) : {};
+            if (!sanitized || !sanitized.cta_copy) {
+              return control("invalid_treatment_config");
+            }
+            if (input.ctaEl) {
+              configApi.applyCtaCopy(input.ctaEl, sanitized.cta_copy);
+            }
+          } else if (input.ctaEl && !input.ctaEl.textContent) {
+            input.ctaEl.textContent = CONTROL_COPY;
+          }
+          if (!telemetryApi || typeof telemetryApi.send !== "function") {
+            return { variant: chosen.role, experiment: experiment, variantId: chosen.variant_id };
+          }
+          var assignmentId = telemetryApi.assignmentEventId
+            ? telemetryApi.assignmentEventId(experiment.id, input.anonymousId, experiment.assignment_version)
+            : ["experiment.assigned", experiment.id, input.anonymousId, experiment.assignment_version].join(":");
+          return telemetryApi
+            .send({
+              url: input.eventsUrl,
+              fetch: input.fetch,
+              name: "experiment.assigned",
+              eventId: assignmentId,
+              anonymousId: input.anonymousId,
+              sessionId: input.sessionId,
+              experimentId: experiment.id,
+              variantId: chosen.variant_id,
+              assignmentVersion: experiment.assignment_version,
+              placement: experiment.placement,
+            })
+            .then(function () {
+              return {
+                variant: chosen.role,
+                experiment: experiment,
+                variantId: chosen.variant_id,
+              };
+            })
+            .catch(function () {
+              return control("telemetry_failure");
+            });
+        });
       })
       .catch(function () {
-        return { variant: "CONTROL", reason: "network_failure" };
+        return control("network_failure");
       });
   }
 

--- a/web/js/growth-experiment-telemetry.js
+++ b/web/js/growth-experiment-telemetry.js
@@ -1,0 +1,52 @@
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  root.HIAIR_GROWTH_EXPERIMENT_TELEMETRY = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  function assignmentEventId(experimentId, anonymousId, assignmentVersion) {
+    return ["experiment.assigned", experimentId, anonymousId, assignmentVersion].join(":");
+  }
+
+  function send(input) {
+    if (!input.url || !input.fetch) {
+      return Promise.resolve({ ok: false });
+    }
+    var body = {
+      productSlug: "hiair",
+      surface: "website",
+      environment: "production",
+      event_version: 2,
+      anonymousId: input.anonymousId,
+      session_id: input.sessionId,
+      event_id: input.eventId,
+      name: input.name,
+      occurredAt: new Date().toISOString(),
+      properties: {
+        placement: input.placement,
+        experiment_id: input.experimentId,
+        variant_id: input.variantId,
+        assignment_version: input.assignmentVersion,
+      },
+    };
+    return input
+      .fetch(input.url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+        keepalive: true,
+      })
+      .then(function (response) {
+        if (!response || !response.ok) {
+          throw new Error("transport");
+        }
+        return { ok: true };
+      });
+  }
+
+  return {
+    assignmentEventId: assignmentEventId,
+    send: send,
+  };
+});

--- a/web/js/growth-experiment.test.cjs
+++ b/web/js/growth-experiment.test.cjs
@@ -1,0 +1,143 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const assignment = require("./growth-experiment-assignment.js");
+const exposure = require("./growth-experiment-exposure.js");
+const config = require("./growth-experiment-config.js");
+const telemetry = require("./growth-experiment-telemetry.js");
+const runtime = require("./growth-experiment-runtime.js");
+
+const EXPERIMENT_ID = "11111111-1111-4111-8111-111111111111";
+const CONTROL = "22222222-2222-4222-8222-222222222222";
+const TREATMENT = "33333333-3333-4333-8333-333333333333";
+const allocation = [
+  { variant_id: CONTROL, role: "CONTROL", weight: 0.5, public_config: {} },
+  { variant_id: TREATMENT, role: "TREATMENT", weight: 0.5, public_config: { cta_copy: "Get HiAir on the App Store" } },
+];
+
+function memoryStorage() {
+  const mem = new Map();
+  return {
+    getItem: (key) => mem.get(key) ?? null,
+    setItem: (key, value) => mem.set(key, String(value)),
+  };
+}
+
+test("flag off and missing config stay CONTROL", async () => {
+  const result = await runtime.start({ enabled: false });
+  assert.equal(result.variant, "CONTROL");
+  const empty = await config.failClosedFetch({ enabled: true, url: "", fetch: null });
+  assert.deepEqual(empty, { experiments: [] });
+});
+
+test("sticky assignment does not change across sessions", () => {
+  const storage = memoryStorage();
+  const first = assignment.assignVisitor({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-sticky",
+    allocation,
+    storage,
+  });
+  const second = assignment.assignVisitor({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-sticky",
+    allocation,
+    storage,
+  });
+  assert.equal(first.variant_id, second.variant_id);
+  assert.equal(second.source, "sticky");
+});
+
+test("exposure requires 50% for 1000ms and retries after transport failure", async () => {
+  assert.equal(exposure.conditionMet(0.49, 5000), false);
+  assert.equal(exposure.conditionMet(0.5, 999), false);
+  assert.equal(exposure.conditionMet(0.5, 1000), true);
+  let now = 0;
+  let attempts = 0;
+  const watcher = exposure.watchExposure({
+    experimentId: EXPERIMENT_ID,
+    variantId: CONTROL,
+    anonymousId: "anon",
+    placement: "header",
+    now: () => now,
+    send: () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return Promise.reject(new Error("network"));
+      }
+      return Promise.resolve();
+    },
+  });
+  watcher.onRatio(0.5);
+  now = 1000;
+  watcher.onRatio(0.5);
+  await Promise.resolve();
+  await Promise.resolve();
+  watcher.onRatio(0.5);
+  now = 2000;
+  watcher.onRatio(0.5);
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.equal(attempts, 2);
+});
+
+test("public config rejects script payloads and applies textContent only", () => {
+  assert.deepEqual(config.publicConfig({ cta_copy: "<script>x</script>" }), {});
+  const el = { textContent: "Download on the App Store" };
+  config.applyCtaCopy(el, "Get HiAir on the App Store");
+  assert.equal(el.textContent, "Get HiAir on the App Store");
+});
+
+test("runtime fail-closed when fetch throws", async () => {
+  const result = await runtime.start({
+    enabled: true,
+    configUrl: "https://growth.example/api/v1/experiments/active",
+    fetch: () => Promise.reject(new Error("down")),
+    configApi: config,
+    assignmentApi: assignment,
+    telemetryApi: telemetry,
+    exposureApi: exposure,
+    anonymousId: "anon",
+    sessionId: "s1",
+    storage: memoryStorage(),
+  });
+  assert.equal(result.variant, "CONTROL");
+});
+
+test("10k hash assignments stay near 50/50 and do not switch", () => {
+  let control = 0;
+  let switches = 0;
+  for (let i = 0; i < 10000; i += 1) {
+    const assigned = assignment.assignFromHash({
+      experimentId: EXPERIMENT_ID,
+      assignmentVersion: "v1",
+      anonymousId: "pop-" + i,
+      allocation,
+    });
+    if (assigned.role === "CONTROL") {
+      control += 1;
+    }
+  }
+  assert.ok(control >= 4700 && control <= 5300, "control=" + control);
+  for (let i = 0; i < 1000; i += 1) {
+    const first = assignment.assignFromHash({
+      experimentId: EXPERIMENT_ID,
+      assignmentVersion: "v1",
+      anonymousId: "sticky-" + i,
+      allocation,
+    });
+    for (let round = 0; round < 5; round += 1) {
+      const again = assignment.assignFromHash({
+        experimentId: EXPERIMENT_ID,
+        assignmentVersion: "v1",
+        anonymousId: "sticky-" + i,
+        allocation,
+      });
+      if (again.variant_id !== first.variant_id) {
+        switches += 1;
+      }
+    }
+  }
+  assert.equal(switches, 0);
+});

--- a/web/js/growth-experiment.test.cjs
+++ b/web/js/growth-experiment.test.cjs
@@ -1,11 +1,14 @@
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const assignment = require("./growth-experiment-assignment.js");
 const exposure = require("./growth-experiment-exposure.js");
 const config = require("./growth-experiment-config.js");
 const telemetry = require("./growth-experiment-telemetry.js");
 const runtime = require("./growth-experiment-runtime.js");
 
+const golden = JSON.parse(fs.readFileSync(path.join(__dirname, "assignment-golden-vectors.json"), "utf8"));
 const EXPERIMENT_ID = "11111111-1111-4111-8111-111111111111";
 const CONTROL = "22222222-2222-4222-8222-222222222222";
 const TREATMENT = "33333333-3333-4333-8333-333333333333";
@@ -22,23 +25,70 @@ function memoryStorage() {
   };
 }
 
-test("flag off and missing config stay CONTROL", async () => {
-  const result = await runtime.start({ enabled: false });
+function experimentPayload(overrides) {
+  return {
+    id: EXPERIMENT_ID,
+    assignment_version: "v1",
+    surface: "website",
+    placement: "header",
+    allocation,
+    ...overrides,
+  };
+}
+
+test("flag off does not fetch config or apply treatment", async () => {
+  let fetches = 0;
+  const cta = { textContent: "Download on the App Store" };
+  const result = await runtime.start({
+    enabled: false,
+    configUrl: "https://growth.example/api/v1/experiments/active",
+    fetch: () => {
+      fetches += 1;
+      return Promise.resolve({ ok: true, json: async () => ({ experiments: [experimentPayload()] }) });
+    },
+    configApi: config,
+    assignmentApi: assignment,
+    telemetryApi: telemetry,
+    ctaEl: cta,
+  });
   assert.equal(result.variant, "CONTROL");
-  const empty = await config.failClosedFetch({ enabled: true, url: "", fetch: null });
-  assert.deepEqual(empty, { experiments: [] });
+  assert.equal(result.reason, "flag_off");
+  assert.equal(fetches, 0);
+  assert.equal(cta.textContent, "Download on the App Store");
 });
 
-test("sticky assignment does not change across sessions", () => {
+test("golden vectors match Web Crypto SHA-256 prefixes and variants", async () => {
+  assert.equal(golden.vectors.length, 20);
+  for (const vector of golden.vectors) {
+    const hex = await assignment.sha256Hex(
+      `${vector.experiment_id}:${vector.assignment_version}:${vector.anonymous_id}`,
+    );
+    assert.ok(hex, "sha256 missing for " + vector.anonymous_id);
+    assert.equal(hex.slice(0, 12), vector.sha256_prefix, vector.anonymous_id);
+    const assigned = await assignment.assignFromHash({
+      experimentId: vector.experiment_id,
+      assignmentVersion: vector.assignment_version,
+      anonymousId: vector.anonymous_id,
+      allocation: golden.allocation,
+    });
+    assert.equal(assigned.source, "hash");
+    assert.equal(assigned.sha256_prefix, vector.sha256_prefix);
+    assert.equal(assigned.role, vector.expected_role);
+    assert.equal(assigned.variant_id, vector.expected_variant_id);
+    assert.ok(Math.abs(assigned.bucket - vector.expected_bucket) < 1e-12);
+  }
+});
+
+test("sticky assignment does not change across sessions", async () => {
   const storage = memoryStorage();
-  const first = assignment.assignVisitor({
+  const first = await assignment.assignVisitor({
     experimentId: EXPERIMENT_ID,
     assignmentVersion: "v1",
     anonymousId: "anon-sticky",
     allocation,
     storage,
   });
-  const second = assignment.assignVisitor({
+  const second = await assignment.assignVisitor({
     experimentId: EXPERIMENT_ID,
     assignmentVersion: "v1",
     anonymousId: "anon-sticky",
@@ -47,6 +97,107 @@ test("sticky assignment does not change across sessions", () => {
   });
   assert.equal(first.variant_id, second.variant_id);
   assert.equal(second.source, "sticky");
+});
+
+test("assignment_version v2 does not leak v1 sticky assignment", async () => {
+  const storage = memoryStorage();
+  const v1 = await assignment.assignVisitor({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-versioned",
+    allocation,
+    storage,
+  });
+  const v2 = await assignment.assignVisitor({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v2",
+    anonymousId: "anon-versioned",
+    allocation,
+    storage,
+  });
+  assert.equal(v1.source, "hash");
+  assert.equal(v2.source, "hash");
+  assert.notEqual(assignment.storageKey(EXPERIMENT_ID, "v1"), assignment.storageKey(EXPERIMENT_ID, "v2"));
+  assert.ok(storage.getItem(assignment.storageKey(EXPERIMENT_ID, "v1")));
+  assert.ok(storage.getItem(assignment.storageKey(EXPERIMENT_ID, "v2")));
+});
+
+test("sticky visitor stays put when allocation weights change for the same version", async () => {
+  const storage = memoryStorage();
+  const first = await assignment.assignVisitor({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-weight",
+    allocation,
+    storage,
+  });
+  const skewed = [
+    { variant_id: CONTROL, role: "CONTROL", weight: 0.01, public_config: {} },
+    { variant_id: TREATMENT, role: "TREATMENT", weight: 0.99, public_config: { cta_copy: "Get HiAir on the App Store" } },
+  ];
+  const second = await assignment.assignVisitor({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-weight",
+    allocation: skewed,
+    storage,
+  });
+  assert.equal(second.source, "sticky");
+  assert.equal(second.variant_id, first.variant_id);
+});
+
+test("unknown stored variant is not executed", async () => {
+  const storage = memoryStorage();
+  storage.setItem(
+    assignment.storageKey(EXPERIMENT_ID, "v1"),
+    JSON.stringify({
+      variant_id: "99999999-9999-4999-8999-999999999999",
+      experiment_id: EXPERIMENT_ID,
+      assignment_version: "v1",
+    }),
+  );
+  const assigned = await assignment.assignVisitor({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-stale",
+    allocation,
+    storage,
+  });
+  assert.notEqual(assigned.variant_id, "99999999-9999-4999-8999-999999999999");
+  assert.ok(assigned.source === "hash" || assigned.source === "control_fallback");
+});
+
+test("storage unavailable and write failure return CONTROL not treatment", async () => {
+  const hashed = await assignment.assignFromHash({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-golden-00",
+    allocation,
+  });
+  assert.equal(hashed.role, "TREATMENT");
+  const noStorage = await assignment.assignVisitor({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-golden-00",
+    allocation,
+  });
+  assert.equal(noStorage.role, "CONTROL");
+  assert.equal(noStorage.source, "control_fallback");
+  const failing = {
+    getItem: () => null,
+    setItem: () => {
+      throw new Error("quota");
+    },
+  };
+  const writeFail = await assignment.assignVisitor({
+    experimentId: EXPERIMENT_ID,
+    assignmentVersion: "v1",
+    anonymousId: "anon-golden-00",
+    allocation,
+    storage: failing,
+  });
+  assert.equal(writeFail.role, "CONTROL");
+  assert.equal(writeFail.reason, "storage_write_failure");
 });
 
 test("exposure requires 50% for 1000ms and retries after transport failure", async () => {
@@ -87,6 +238,94 @@ test("public config rejects script payloads and applies textContent only", () =>
   const el = { textContent: "Download on the App Store" };
   config.applyCtaCopy(el, "Get HiAir on the App Store");
   assert.equal(el.textContent, "Get HiAir on the App Store");
+  assert.equal(Object.prototype.hasOwnProperty.call(el, "innerHTML"), false);
+});
+
+test("control fallback matrix never applies treatment", async () => {
+  const cta = { textContent: "Download on the App Store" };
+  const cases = [
+    {
+      name: "config unavailable",
+      input: {
+        enabled: true,
+        configUrl: "https://growth.example/api/v1/experiments/active",
+        fetch: () => Promise.reject(new Error("down")),
+      },
+    },
+    {
+      name: "empty config",
+      input: {
+        enabled: true,
+        configUrl: "https://growth.example/api/v1/experiments/active",
+        fetch: () => Promise.resolve({ ok: true, json: async () => ({ experiments: [] }) }),
+      },
+    },
+    {
+      name: "malformed experiment",
+      input: {
+        enabled: true,
+        configUrl: "https://growth.example/api/v1/experiments/active",
+        fetch: () => Promise.resolve({ ok: true, json: async () => ({ experiments: [{ id: "x" }] }) }),
+      },
+    },
+    {
+      name: "missing CONTROL",
+      input: {
+        enabled: true,
+        configUrl: "https://growth.example/api/v1/experiments/active",
+        fetch: () =>
+          Promise.resolve({
+            ok: true,
+            json: async () => ({
+              experiments: [
+                experimentPayload({
+                  allocation: [{ variant_id: TREATMENT, role: "TREATMENT", weight: 1, public_config: { cta_copy: "Treat" } }],
+                }),
+              ],
+            }),
+          }),
+      },
+    },
+    {
+      name: "invalid treatment config",
+      input: {
+        enabled: true,
+        configUrl: "https://growth.example/api/v1/experiments/active",
+        fetch: () =>
+          Promise.resolve({
+            ok: true,
+            json: async () => ({
+              experiments: [
+                experimentPayload({
+                  allocation: [
+                    { variant_id: CONTROL, role: "CONTROL", weight: 0, public_config: {} },
+                    { variant_id: TREATMENT, role: "TREATMENT", weight: 1, public_config: { cta_copy: "<script>x</script>" } },
+                  ],
+                }),
+              ],
+            }),
+          }),
+        storage: memoryStorage(),
+        anonymousId: "anon-golden-00",
+      },
+    },
+  ];
+  for (const row of cases) {
+    cta.textContent = "Download on the App Store";
+    const result = await runtime.start({
+      configApi: config,
+      assignmentApi: assignment,
+      telemetryApi: telemetry,
+      exposureApi: exposure,
+      ctaEl: cta,
+      anonymousId: "anon",
+      sessionId: "s1",
+      eventsUrl: "",
+      ...row.input,
+    });
+    assert.equal(result.variant, "CONTROL", row.name);
+    assert.equal(cta.textContent, "Download on the App Store", row.name);
+  }
 });
 
 test("runtime fail-closed when fetch throws", async () => {
@@ -103,41 +342,4 @@ test("runtime fail-closed when fetch throws", async () => {
     storage: memoryStorage(),
   });
   assert.equal(result.variant, "CONTROL");
-});
-
-test("10k hash assignments stay near 50/50 and do not switch", () => {
-  let control = 0;
-  let switches = 0;
-  for (let i = 0; i < 10000; i += 1) {
-    const assigned = assignment.assignFromHash({
-      experimentId: EXPERIMENT_ID,
-      assignmentVersion: "v1",
-      anonymousId: "pop-" + i,
-      allocation,
-    });
-    if (assigned.role === "CONTROL") {
-      control += 1;
-    }
-  }
-  assert.ok(control >= 4700 && control <= 5300, "control=" + control);
-  for (let i = 0; i < 1000; i += 1) {
-    const first = assignment.assignFromHash({
-      experimentId: EXPERIMENT_ID,
-      assignmentVersion: "v1",
-      anonymousId: "sticky-" + i,
-      allocation,
-    });
-    for (let round = 0; round < 5; round += 1) {
-      const again = assignment.assignFromHash({
-        experimentId: EXPERIMENT_ID,
-        assignmentVersion: "v1",
-        anonymousId: "sticky-" + i,
-        allocation,
-      });
-      if (again.variant_id !== first.variant_id) {
-        switches += 1;
-      }
-    }
-  }
-  assert.equal(switches, 0);
 });

--- a/web/js/growth-telemetry.test.cjs
+++ b/web/js/growth-telemetry.test.cjs
@@ -89,6 +89,39 @@ test("view event is not duplicated for the same placement", () => {
   assert.equal(body.event_id, "id-1");
 });
 
+test("flag off does not start experiment runtime or emit experiment telemetry", () => {
+  let starts = 0;
+  const calls = [];
+  const win = fakeWindow({
+    eventsUrl: "https://growth.example/api/v1/events",
+    fetch: (...args) => {
+      calls.push(args);
+      return Promise.resolve();
+    },
+  });
+  win.HIAIR_GROWTH_EXPERIMENT = {
+    start: () => {
+      starts += 1;
+      return Promise.resolve({ variant: "TREATMENT" });
+    },
+  };
+  loadMain(win);
+  assert.equal(starts, 0);
+  const names = calls.map((call) => JSON.parse(call[1].body).name);
+  assert.ok(names.every((name) => name === "app_store_cta.viewed" || name === "app_store_cta.clicked"));
+  assert.equal(
+    names.includes("experiment.assigned") || names.includes("experiment.exposed"),
+    false,
+  );
+});
+
+test("production HTML does not load experiment scripts", () => {
+  const html = fs.readFileSync(path.join(__dirname, "..", "index.html"), "utf8");
+  assert.equal(html.includes("growth-experiment"), false);
+  const main = fs.readFileSync(path.join(__dirname, "main.js"), "utf8");
+  assert.match(main, /var HIAIR_EXPERIMENTS_ENABLED = false;/);
+});
+
 test("click emits once and CTA still works if telemetry rejects", () => {
   const calls = [];
   const win = fakeWindow({

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -314,6 +314,8 @@
     });
   }
 
+  var HIAIR_EXPERIMENTS_ENABLED = false;
+
   var storeCtas = document.querySelectorAll(".js-app-store-cta");
   if (storeCtas.length) {
     var viewed = {};
@@ -337,5 +339,9 @@
         });
       });
     });
+  }
+
+  if (HIAIR_EXPERIMENTS_ENABLED && window.HIAIR_GROWTH_EXPERIMENT && typeof window.HIAIR_GROWTH_EXPERIMENT.start === "function") {
+    window.HIAIR_GROWTH_EXPERIMENT.start({ enabled: true });
   }
 })();


### PR DESCRIPTION
## Summary
- Proven production website source-of-truth is **`main` / `web/`** via Cloudflare Pages (`hiair-io-pages.yml`), not GitHub default `cursor/bootstrap-ci-and-tooling`.
- Browser assignment uses **async `crypto.subtle.digest("SHA-256")`**. No CommonJS `require("crypto")`. Crypto or `localStorage` failure → CONTROL.
- 20/20 golden vectors match Growth OS. Browser 10k allocation: CONTROL 4973 / TREATMENT 5027. Sticky switches = 0 across 1000 reloads.
- `HIAIR_EXPERIMENTS_ENABLED` is **false**. Production HTML does not load experiment modules. No config request, no treatment.

## Test plan
- [x] Node/CommonJS: 22 passed (`store-links`, `growth-telemetry`, `growth-experiment`)
- [x] Browser/WebCrypto VM (`require` undefined): 5 passed
- [x] Flag-off: 3 passed (no config fetch, no runtime start, HTML has no experiment scripts)
- [x] Exposure: 49% / <1000ms / ≥1000ms / retry
- [x] GitHub `hiair-io-pages` **validate PASS**; **deploy SKIPPED** on the PR
- [ ] App Store Connect Archive-iOS remains unrelated and is **not** treated as a website failure
- [x] After merge: keep `HIAIR_EXPERIMENTS_ENABLED=false`; no treatment